### PR TITLE
feat: form scheme templates

### DIFF
--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -843,6 +843,96 @@ Resources:
             Path: /org/courses/{courseId}/form-schema/versions/{version}
             Method: GET
 
+  OrgFormTemplatesListFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../deploy/lambda.zip
+      Handler: dist/services/api/src/handlers/orgFormTemplatesList.handler
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref OnlineFormsMainTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref OnlineFormsAuthTable
+      Events:
+        OrgFormTemplatesListRoute:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref OnlineFormsHttpApi
+            Path: /org/form-templates
+            Method: GET
+
+  OrgFormTemplatesCreateFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../deploy/lambda.zip
+      Handler: dist/services/api/src/handlers/orgFormTemplatesCreate.handler
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref OnlineFormsMainTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref OnlineFormsAuthTable
+      Events:
+        OrgFormTemplatesCreateRoute:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref OnlineFormsHttpApi
+            Path: /org/form-templates
+            Method: POST
+
+  OrgFormTemplatesGetFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../deploy/lambda.zip
+      Handler: dist/services/api/src/handlers/orgFormTemplatesGet.handler
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref OnlineFormsMainTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref OnlineFormsAuthTable
+      Events:
+        OrgFormTemplatesGetRoute:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref OnlineFormsHttpApi
+            Path: /org/form-templates/{templateId}
+            Method: GET
+
+  OrgFormTemplatesUpdateFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../deploy/lambda.zip
+      Handler: dist/services/api/src/handlers/orgFormTemplatesUpdate.handler
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref OnlineFormsMainTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref OnlineFormsAuthTable
+      Events:
+        OrgFormTemplatesUpdateRoute:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref OnlineFormsHttpApi
+            Path: /org/form-templates/{templateId}
+            Method: PATCH
+
+  OrgFormTemplatesDeleteFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../deploy/lambda.zip
+      Handler: dist/services/api/src/handlers/orgFormTemplatesDelete.handler
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref OnlineFormsMainTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref OnlineFormsAuthTable
+      Events:
+        OrgFormTemplatesDeleteRoute:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref OnlineFormsHttpApi
+            Path: /org/form-templates/{templateId}
+            Method: DELETE
+
   OrgSubmissionsListFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -23,8 +23,114 @@ tags:
   name: Public Enrollment
 - description: Internal platform tenant administration endpoints
   name: Platform Tenants
+- description: Organization form schema template library endpoints
+  name: Org Form Templates
 components:
   schemas:
+    FormTemplate:
+      type: object
+      properties:
+        templateId:
+          type: string
+        tenantId:
+          type: string
+        name:
+          type: string
+          minLength: 1
+          maxLength: 120
+        description:
+          type:
+          - string
+          - "null"
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/FormField'
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        createdBy:
+          type: string
+        updatedBy:
+          type: string
+      required:
+      - templateId
+      - tenantId
+      - name
+      - fields
+      - createdAt
+      - updatedAt
+      - createdBy
+      - updatedBy
+    FormTemplateResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/FormTemplate'
+      required:
+      - data
+    FormTemplateListResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/FormTemplate'
+      required:
+      - data
+    CreateFormTemplateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 120
+        description:
+          type:
+          - string
+          - "null"
+        fields:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/FormField'
+      required:
+      - name
+      - fields
+    UpdateFormTemplateRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 120
+        description:
+          type:
+          - string
+          - "null"
+        fields:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/FormField'
+    DeleteFormTemplateResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            deleted:
+              type: boolean
+            templateId:
+              type: string
+          required:
+          - deleted
+          - templateId
+      required:
+      - data
     FormSchemaResponse:
       properties:
         data:
@@ -1682,6 +1788,12 @@ components:
       in: query
       schema:
         type: string
+    TemplateId:
+      name: templateId
+      in: path
+      schema:
+        type: string
+      required: true
     FormVersion:
       name: version
       in: path
@@ -1794,6 +1906,101 @@ servers:
 - url: https://api.onlineforms.com
   description: Production example
 paths:
+  /v1/org/form-templates:
+    get:
+      summary: List form templates
+      tags:
+      - Org Form Templates
+      security:
+      - bearerAuth: []
+      responses:
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FormTemplateListResponse'
+          description: List of form templates
+    post:
+      summary: Create form template
+      tags:
+      - Org Form Templates
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateFormTemplateRequest'
+      responses:
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FormTemplateResponse'
+          description: Form template created
+  /v1/org/form-templates/{templateId}:
+    get:
+      summary: Get form template
+      tags:
+      - Org Form Templates
+      security:
+      - bearerAuth: []
+      parameters:
+      - $ref: '#/components/parameters/TemplateId'
+      responses:
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FormTemplateResponse'
+          description: Form template
+    patch:
+      summary: Update form template
+      tags:
+      - Org Form Templates
+      security:
+      - bearerAuth: []
+      parameters:
+      - $ref: '#/components/parameters/TemplateId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateFormTemplateRequest'
+      responses:
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FormTemplateResponse'
+          description: Form template updated
+    delete:
+      summary: Delete form template
+      tags:
+      - Org Form Templates
+      security:
+      - bearerAuth: []
+      parameters:
+      - $ref: '#/components/parameters/TemplateId'
+      responses:
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteFormTemplateResponse'
+          description: Form template deleted
   /v1/org/me:
     get:
       summary: Get authenticated org session

--- a/services/api/src/handlers/orgFormTemplatesCreate.ts
+++ b/services/api/src/handlers/orgFormTemplatesCreate.ts
@@ -1,0 +1,48 @@
+import type { APIGatewayProxyHandlerV2 } from "aws-lambda";
+import { authenticateRequest } from "../lib/auth";
+import { authorizeOrgAction } from "../lib/authorization";
+import { writeAuditEvent } from "../lib/audit";
+import { createCorrelationContext } from "../lib/correlation";
+import { createFormTemplate, type FormField } from "../lib/formTemplates";
+import { ApiError } from "../lib/errors";
+import { errorResponse, jsonResponse } from "../lib/http";
+import { parseJsonBody } from "../lib/request";
+
+type CreateTemplateBody = {
+  name: string;
+  description?: string | null;
+  fields: FormField[];
+};
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const correlation = createCorrelationContext(event.requestContext.requestId, event.headers);
+  try {
+    const auth = await authenticateRequest(event.headers);
+    authorizeOrgAction(auth, "ORG_FORM_WRITE");
+
+    const body = parseJsonBody<CreateTemplateBody>(event);
+    if (!body.name) throw new ApiError(400, "VALIDATION_ERROR", "name is required.");
+    if (!Array.isArray(body.fields)) throw new ApiError(400, "VALIDATION_ERROR", "fields must be an array.");
+
+    const template = await createFormTemplate(auth.tenantId, auth.userId, {
+      name: body.name,
+      description: body.description,
+      fields: body.fields,
+    });
+
+    await writeAuditEvent({
+      tenantId: auth.tenantId,
+      actorUserId: auth.userId,
+      action: "form_template.create",
+      resourceType: "form_template",
+      resourceId: template.templateId,
+      correlationId: correlation.correlationId,
+      requestId: correlation.requestId,
+      details: { templateId: template.templateId, name: template.name, fieldCount: template.fields.length },
+    });
+
+    return jsonResponse(201, { data: template }, correlation);
+  } catch (error) {
+    return errorResponse(error, correlation);
+  }
+};

--- a/services/api/src/handlers/orgFormTemplatesDelete.ts
+++ b/services/api/src/handlers/orgFormTemplatesDelete.ts
@@ -1,0 +1,36 @@
+import type { APIGatewayProxyHandlerV2 } from "aws-lambda";
+import { authenticateRequest } from "../lib/auth";
+import { authorizeOrgAction } from "../lib/authorization";
+import { writeAuditEvent } from "../lib/audit";
+import { createCorrelationContext } from "../lib/correlation";
+import { deleteFormTemplate } from "../lib/formTemplates";
+import { ApiError } from "../lib/errors";
+import { errorResponse, jsonResponse } from "../lib/http";
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const correlation = createCorrelationContext(event.requestContext.requestId, event.headers);
+  try {
+    const auth = await authenticateRequest(event.headers);
+    authorizeOrgAction(auth, "ORG_FORM_WRITE");
+
+    const templateId = event.pathParameters?.templateId;
+    if (!templateId) throw new ApiError(400, "VALIDATION_ERROR", "Missing templateId path parameter.");
+
+    await deleteFormTemplate(auth.tenantId, templateId);
+
+    await writeAuditEvent({
+      tenantId: auth.tenantId,
+      actorUserId: auth.userId,
+      action: "form_template.delete",
+      resourceType: "form_template",
+      resourceId: templateId,
+      correlationId: correlation.correlationId,
+      requestId: correlation.requestId,
+      details: { templateId },
+    });
+
+    return jsonResponse(200, { data: { deleted: true, templateId } }, correlation);
+  } catch (error) {
+    return errorResponse(error, correlation);
+  }
+};

--- a/services/api/src/handlers/orgFormTemplatesGet.ts
+++ b/services/api/src/handlers/orgFormTemplatesGet.ts
@@ -1,0 +1,24 @@
+import type { APIGatewayProxyHandlerV2 } from "aws-lambda";
+import { authenticateRequest } from "../lib/auth";
+import { authorizeOrgAction } from "../lib/authorization";
+import { createCorrelationContext } from "../lib/correlation";
+import { getFormTemplate } from "../lib/formTemplates";
+import { ApiError } from "../lib/errors";
+import { errorResponse, jsonResponse } from "../lib/http";
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const correlation = createCorrelationContext(event.requestContext.requestId, event.headers);
+  try {
+    const auth = await authenticateRequest(event.headers);
+    authorizeOrgAction(auth, "ORG_FORM_READ");
+
+    const templateId = event.pathParameters?.templateId;
+    if (!templateId) throw new ApiError(400, "VALIDATION_ERROR", "Missing templateId path parameter.");
+
+    const template = await getFormTemplate(auth.tenantId, templateId);
+
+    return jsonResponse(200, { data: template }, correlation);
+  } catch (error) {
+    return errorResponse(error, correlation);
+  }
+};

--- a/services/api/src/handlers/orgFormTemplatesList.ts
+++ b/services/api/src/handlers/orgFormTemplatesList.ts
@@ -1,0 +1,20 @@
+import type { APIGatewayProxyHandlerV2 } from "aws-lambda";
+import { authenticateRequest } from "../lib/auth";
+import { authorizeOrgAction } from "../lib/authorization";
+import { createCorrelationContext } from "../lib/correlation";
+import { listFormTemplates } from "../lib/formTemplates";
+import { errorResponse, jsonResponse } from "../lib/http";
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const correlation = createCorrelationContext(event.requestContext.requestId, event.headers);
+  try {
+    const auth = await authenticateRequest(event.headers);
+    authorizeOrgAction(auth, "ORG_FORM_READ");
+
+    const templates = await listFormTemplates(auth.tenantId);
+
+    return jsonResponse(200, { data: templates }, correlation);
+  } catch (error) {
+    return errorResponse(error, correlation);
+  }
+};

--- a/services/api/src/handlers/orgFormTemplatesUpdate.ts
+++ b/services/api/src/handlers/orgFormTemplatesUpdate.ts
@@ -1,0 +1,49 @@
+import type { APIGatewayProxyHandlerV2 } from "aws-lambda";
+import { authenticateRequest } from "../lib/auth";
+import { authorizeOrgAction } from "../lib/authorization";
+import { writeAuditEvent } from "../lib/audit";
+import { createCorrelationContext } from "../lib/correlation";
+import { updateFormTemplate, type FormField } from "../lib/formTemplates";
+import { ApiError } from "../lib/errors";
+import { errorResponse, jsonResponse } from "../lib/http";
+import { parseJsonBody } from "../lib/request";
+
+type UpdateTemplateBody = {
+  name?: string;
+  description?: string | null;
+  fields?: FormField[];
+};
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const correlation = createCorrelationContext(event.requestContext.requestId, event.headers);
+  try {
+    const auth = await authenticateRequest(event.headers);
+    authorizeOrgAction(auth, "ORG_FORM_WRITE");
+
+    const templateId = event.pathParameters?.templateId;
+    if (!templateId) throw new ApiError(400, "VALIDATION_ERROR", "Missing templateId path parameter.");
+
+    const body = parseJsonBody<UpdateTemplateBody>(event);
+
+    const template = await updateFormTemplate(auth.tenantId, templateId, auth.userId, {
+      name: body.name,
+      description: body.description,
+      fields: body.fields,
+    });
+
+    await writeAuditEvent({
+      tenantId: auth.tenantId,
+      actorUserId: auth.userId,
+      action: "form_template.update",
+      resourceType: "form_template",
+      resourceId: templateId,
+      correlationId: correlation.correlationId,
+      requestId: correlation.requestId,
+      details: { templateId, name: template.name },
+    });
+
+    return jsonResponse(200, { data: template }, correlation);
+  } catch (error) {
+    return errorResponse(error, correlation);
+  }
+};

--- a/services/api/src/lib/audit.ts
+++ b/services/api/src/lib/audit.ts
@@ -14,13 +14,16 @@ export type AuditAction =
   | "tenant.create"
   | "tenant.update"
   | "tenant.activate"
-  | "tenant.deactivate";
+  | "tenant.deactivate"
+  | "form_template.create"
+  | "form_template.update"
+  | "form_template.delete";
 
 export type AuditEventInput = {
   tenantId: string;
   actorUserId: string;
   action: AuditAction;
-  resourceType: "course" | "form" | "submission" | "branding" | "tenant";
+  resourceType: "course" | "form" | "form_template" | "submission" | "branding" | "tenant";
   resourceId: string;
   correlationId: string;
   requestId: string;

--- a/services/api/src/lib/formTemplates.ts
+++ b/services/api/src/lib/formTemplates.ts
@@ -1,0 +1,253 @@
+import { randomUUID } from "crypto";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  DeleteCommand,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { ApiError } from "./errors";
+import { validateFormFields, type FormField } from "./formSchemas";
+
+export type { FormField };
+
+export type FormTemplate = {
+  templateId: string;
+  tenantId: string;
+  name: string;
+  description: string | null;
+  fields: FormField[];
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+  updatedBy: string;
+};
+
+export type CreateFormTemplateInput = {
+  name: string;
+  description?: string | null;
+  fields: FormField[];
+};
+
+export type UpdateFormTemplateInput = {
+  name?: string;
+  description?: string | null;
+  fields?: FormField[];
+};
+
+type FormTemplateItem = {
+  PK: string;
+  SK: string;
+  entityType: "FORM_TEMPLATE";
+  templateId: string;
+  tenantId: string;
+  name: string;
+  description: string | null;
+  fields: FormField[];
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+  updatedBy: string;
+};
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const tableName = process.env.ONLINEFORMS_TABLE ?? "OnlineFormsMain";
+let testDdbSendOverride: ((command: object) => Promise<unknown>) | null = null;
+
+async function sendDdb<TResult>(command: object): Promise<TResult> {
+  if (testDdbSendOverride) {
+    return (await testDdbSendOverride(command)) as TResult;
+  }
+  return (await ddb.send(command as never)) as TResult;
+}
+
+function tenantPk(tenantId: string): string {
+  return `TENANT#${tenantId}`;
+}
+
+function templateSk(templateId: string): string {
+  return `FORMTEMPLATE#${templateId}`;
+}
+
+function generateTemplateId(): string {
+  return `ftpl_${randomUUID().replace(/-/g, "").slice(0, 16)}`;
+}
+
+function validateName(name: string): void {
+  if (!name?.trim()) {
+    throw new ApiError(400, "VALIDATION_ERROR", "Template name is required.");
+  }
+  if (name.trim().length > 120) {
+    throw new ApiError(400, "VALIDATION_ERROR", "Template name must be 120 characters or fewer.");
+  }
+}
+
+function fromItem(item: FormTemplateItem): FormTemplate {
+  return {
+    templateId: item.templateId,
+    tenantId: item.tenantId,
+    name: item.name,
+    description: item.description,
+    fields: item.fields,
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
+    createdBy: item.createdBy,
+    updatedBy: item.updatedBy,
+  };
+}
+
+export async function createFormTemplate(
+  tenantId: string,
+  userId: string,
+  input: CreateFormTemplateInput
+): Promise<FormTemplate> {
+  validateName(input.name);
+  validateFormFields(input.fields);
+
+  const templateId = generateTemplateId();
+  const now = new Date().toISOString();
+
+  const item: FormTemplateItem = {
+    PK: tenantPk(tenantId),
+    SK: templateSk(templateId),
+    entityType: "FORM_TEMPLATE",
+    templateId,
+    tenantId,
+    name: input.name.trim(),
+    description: input.description ?? null,
+    fields: input.fields,
+    createdAt: now,
+    updatedAt: now,
+    createdBy: userId,
+    updatedBy: userId,
+  };
+
+  await sendDdb(
+    new PutCommand({
+      TableName: tableName,
+      Item: item,
+      ConditionExpression: "attribute_not_exists(PK) AND attribute_not_exists(SK)",
+    })
+  );
+
+  return fromItem(item);
+}
+
+export async function getFormTemplate(
+  tenantId: string,
+  templateId: string
+): Promise<FormTemplate> {
+  const out = await sendDdb<{ Item?: Record<string, unknown> }>(
+    new GetCommand({
+      TableName: tableName,
+      Key: { PK: tenantPk(tenantId), SK: templateSk(templateId) },
+    })
+  );
+
+  if (!out.Item || (out.Item as FormTemplateItem).entityType !== "FORM_TEMPLATE") {
+    throw new ApiError(404, "NOT_FOUND", "Form template not found.");
+  }
+
+  return fromItem(out.Item as FormTemplateItem);
+}
+
+export async function listFormTemplates(tenantId: string): Promise<FormTemplate[]> {
+  const out = await sendDdb<{ Items?: unknown[] }>(
+    new QueryCommand({
+      TableName: tableName,
+      KeyConditionExpression: "PK = :pk AND begins_with(SK, :sk)",
+      ExpressionAttributeValues: {
+        ":pk": tenantPk(tenantId),
+        ":sk": "FORMTEMPLATE#",
+      },
+    })
+  );
+
+  const items = (out.Items ?? []) as FormTemplateItem[];
+  return items
+    .filter((item) => item.entityType === "FORM_TEMPLATE")
+    .map(fromItem)
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+export async function updateFormTemplate(
+  tenantId: string,
+  templateId: string,
+  userId: string,
+  input: UpdateFormTemplateInput
+): Promise<FormTemplate> {
+  if (Object.keys(input).length === 0) {
+    throw new ApiError(400, "VALIDATION_ERROR", "No fields provided to update.");
+  }
+  if (input.name !== undefined) validateName(input.name);
+  if (input.fields !== undefined) validateFormFields(input.fields);
+
+  const now = new Date().toISOString();
+  const updateParts: string[] = ["#updatedAt = :updatedAt", "#updatedBy = :updatedBy"];
+  const exprNames: Record<string, string> = {
+    "#updatedAt": "updatedAt",
+    "#updatedBy": "updatedBy",
+  };
+  const exprValues: Record<string, unknown> = {
+    ":updatedAt": now,
+    ":updatedBy": userId,
+  };
+
+  if (input.name !== undefined) {
+    updateParts.push("#name = :name");
+    exprNames["#name"] = "name";
+    exprValues[":name"] = input.name.trim();
+  }
+  if (input.description !== undefined) {
+    updateParts.push("#description = :description");
+    exprNames["#description"] = "description";
+    exprValues[":description"] = input.description ?? null;
+  }
+  if (input.fields !== undefined) {
+    updateParts.push("#fields = :fields");
+    exprNames["#fields"] = "fields";
+    exprValues[":fields"] = input.fields;
+  }
+
+  const out = await sendDdb<{ Attributes?: Record<string, unknown> }>(
+    new UpdateCommand({
+      TableName: tableName,
+      Key: { PK: tenantPk(tenantId), SK: templateSk(templateId) },
+      ConditionExpression: "attribute_exists(PK) AND attribute_exists(SK)",
+      UpdateExpression: `SET ${updateParts.join(", ")}`,
+      ExpressionAttributeNames: exprNames,
+      ExpressionAttributeValues: exprValues,
+      ReturnValues: "ALL_NEW",
+    })
+  );
+
+  if (!out.Attributes) {
+    throw new ApiError(404, "NOT_FOUND", "Form template not found.");
+  }
+
+  return fromItem(out.Attributes as FormTemplateItem);
+}
+
+export async function deleteFormTemplate(
+  tenantId: string,
+  templateId: string
+): Promise<void> {
+  await sendDdb(
+    new DeleteCommand({
+      TableName: tableName,
+      Key: { PK: tenantPk(tenantId), SK: templateSk(templateId) },
+      ConditionExpression: "attribute_exists(PK) AND attribute_exists(SK)",
+    })
+  );
+}
+
+export const __formTemplatesTestHooks = {
+  setDdbSendOverride(loader: ((command: object) => Promise<unknown>) | null): void {
+    testDdbSendOverride = loader;
+  },
+  reset(): void {
+    testDdbSendOverride = null;
+  },
+};


### PR DESCRIPTION
## Summary

Introduces a form scheme template library — org editors can create and manage reusable field sets, then apply one when designing a course enrollment form.

- New DynamoDB entity (`FORMTEMPLATE#{templateId}`, prefix `ftpl_`) scoped to tenant — no new table or GSI needed
- Full CRUD via 5 new Lambda handlers; reads require `ORG_FORM_READ`, writes require `ORG_FORM_WRITE` (editor/admin only)
- Audit events (`form_template.create`, `form_template.update`, `form_template.delete`) on all mutations
- OpenAPI spec and SAM infra updated

## Changes

| File | Change |
|---|---|
| `services/api/src/lib/formTemplates.ts` | New — DynamoDB CRUD lib, re-uses `validateFormFields` from `formSchemas.ts` |
| `services/api/src/lib/audit.ts` | Added `form_template.*` audit actions and `"form_template"` resource type |
| `services/api/src/handlers/orgFormTemplatesList.ts` | New — `GET /v1/org/form-templates` |
| `services/api/src/handlers/orgFormTemplatesCreate.ts` | New — `POST /v1/org/form-templates` |
| `services/api/src/handlers/orgFormTemplatesGet.ts` | New — `GET /v1/org/form-templates/{templateId}` |
| `services/api/src/handlers/orgFormTemplatesUpdate.ts` | New — `PATCH /v1/org/form-templates/{templateId}` |
| `services/api/src/handlers/orgFormTemplatesDelete.ts` | New — `DELETE /v1/org/form-templates/{templateId}` |
| `openapi.yaml` | New `FormTemplate` schemas, `TemplateId` parameter, 5 path entries |
| `infra/template.yaml` | 5 new `AWS::Serverless::Function` resources |

## API endpoints

| Method | Path | Auth | Roles |
|---|---|---|---|
| `GET` | `/v1/org/form-templates` | `ORG_FORM_READ` | viewer, editor, admin |
| `POST` | `/v1/org/form-templates` | `ORG_FORM_WRITE` | editor, admin |
| `GET` | `/v1/org/form-templates/{templateId}` | `ORG_FORM_READ` | viewer, editor, admin |
| `PATCH` | `/v1/org/form-templates/{templateId}` | `ORG_FORM_WRITE` | editor, admin |
| `DELETE` | `/v1/org/form-templates/{templateId}` | `ORG_FORM_WRITE` | editor, admin |

## Test plan

- [ ] `POST /v1/org/form-templates` with valid fields → 201, `templateId` starts with `ftpl_`
- [ ] `GET /v1/org/form-templates` → list includes new template
- [ ] `PATCH /v1/org/form-templates/{id}` → 200, updated name persisted
- [ ] `DELETE /v1/org/form-templates/{id}` → 200 `{ deleted: true }`
- [ ] `GET /v1/org/form-templates/{id}` after delete → 404
- [ ] `org_viewer` token on create/update/delete → 403
- [ ] Audit log entries present for create, update, delete actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)