### PR TITLE
feat: course variants

### DIFF
--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -789,6 +789,78 @@ Resources:
             Path: /org/courses/{courseId}/archive
             Method: POST
 
+  OrgCourseVariantsCreateFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../deploy/lambda.zip
+      Handler: dist/services/api/src/handlers/orgCourseVariantsCreate.handler
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref OnlineFormsMainTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref OnlineFormsAuthTable
+      Events:
+        OrgCourseVariantsCreateRoute:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref OnlineFormsHttpApi
+            Path: /org/courses/{courseId}/variants
+            Method: POST
+
+  OrgCourseVariantsListFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../deploy/lambda.zip
+      Handler: dist/services/api/src/handlers/orgCourseVariantsList.handler
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref OnlineFormsMainTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref OnlineFormsAuthTable
+      Events:
+        OrgCourseVariantsListRoute:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref OnlineFormsHttpApi
+            Path: /org/courses/{courseId}/variants
+            Method: GET
+
+  OrgCourseVariantsUpdateFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../deploy/lambda.zip
+      Handler: dist/services/api/src/handlers/orgCourseVariantsUpdate.handler
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref OnlineFormsMainTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref OnlineFormsAuthTable
+      Events:
+        OrgCourseVariantsUpdateRoute:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref OnlineFormsHttpApi
+            Path: /org/courses/{courseId}/variants/{variantId}
+            Method: PATCH
+
+  OrgCourseVariantsDeleteFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../deploy/lambda.zip
+      Handler: dist/services/api/src/handlers/orgCourseVariantsDelete.handler
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref OnlineFormsMainTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref OnlineFormsAuthTable
+      Events:
+        OrgCourseVariantsDeleteRoute:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref OnlineFormsHttpApi
+            Path: /org/courses/{courseId}/variants/{variantId}
+            Method: DELETE
+
   OrgFormSchemaUpsertFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -257,6 +257,185 @@ components:
       - hasActiveForm
       - publishReady
       type: object
+    CourseVariant:
+      type: object
+      properties:
+        id:
+          type: string
+        courseId:
+          type: string
+        tenantId:
+          type: string
+        title:
+          type: string
+          minLength: 1
+          maxLength: 120
+        description:
+          type:
+          - string
+          - "null"
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        deliveryMode:
+          $ref: '#/components/schemas/DeliveryMode'
+        locationText:
+          type:
+          - string
+          - "null"
+        capacity:
+          type:
+          - integer
+          - "null"
+          minimum: 1
+        price:
+          type:
+          - number
+          - "null"
+          description: Reserved for future payment support
+        displayOrder:
+          type: integer
+          minimum: 0
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        createdBy:
+          type: string
+        updatedBy:
+          type: string
+      required:
+      - id
+      - courseId
+      - tenantId
+      - title
+      - startDate
+      - endDate
+      - deliveryMode
+      - displayOrder
+      - createdAt
+      - updatedAt
+    PublicCourseVariant:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        description:
+          type:
+          - string
+          - "null"
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        deliveryMode:
+          $ref: '#/components/schemas/DeliveryMode'
+        locationText:
+          type:
+          - string
+          - "null"
+        capacity:
+          type:
+          - integer
+          - "null"
+        price:
+          type:
+          - number
+          - "null"
+          description: Reserved for future payment support
+        displayOrder:
+          type: integer
+      required:
+      - id
+      - title
+      - startDate
+      - endDate
+      - deliveryMode
+      - displayOrder
+    CreateVariantRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 120
+        description:
+          type:
+          - string
+          - "null"
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        deliveryMode:
+          $ref: '#/components/schemas/DeliveryMode'
+        locationText:
+          type:
+          - string
+          - "null"
+        capacity:
+          type:
+          - integer
+          - "null"
+          minimum: 1
+        price:
+          type:
+          - number
+          - "null"
+        displayOrder:
+          type: integer
+          minimum: 0
+      required:
+      - title
+      - startDate
+      - endDate
+      - deliveryMode
+    UpdateVariantRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 120
+        description:
+          type:
+          - string
+          - "null"
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+        deliveryMode:
+          $ref: '#/components/schemas/DeliveryMode'
+        locationText:
+          type:
+          - string
+          - "null"
+        capacity:
+          type:
+          - integer
+          - "null"
+          minimum: 1
+        price:
+          type:
+          - number
+          - "null"
+        displayOrder:
+          type: integer
+          minimum: 0
     OrgCourse:
       allOf:
       - $ref: '#/components/schemas/Course'
@@ -264,8 +443,13 @@ components:
         properties:
           workflow:
             $ref: '#/components/schemas/OrgCourseWorkflow'
+          variants:
+            type: array
+            items:
+              $ref: '#/components/schemas/CourseVariant'
         required:
         - workflow
+        - variants
     PageMeta:
       properties:
         limit:
@@ -467,6 +651,11 @@ components:
         formVersion:
           type: integer
           minimum: 1
+        variantId:
+          type:
+          - string
+          - "null"
+          description: Required when the course has variants
       type: object
       required:
       - formVersion
@@ -625,6 +814,10 @@ components:
                 - "null"
               formAvailable:
                 type: boolean
+              variants:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PublicCourseVariant'
             type: object
       type: object
       required:
@@ -2320,6 +2513,111 @@ paths:
       - bearerAuth: []
       tags:
       - Org Courses
+  /v1/org/courses/{courseId}/variants:
+    get:
+      parameters:
+      - $ref: '#/components/parameters/CourseId'
+      summary: List course variants
+      security:
+      - bearerAuth: []
+      tags:
+      - Org Courses
+      responses:
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+        "200":
+          description: List of variants
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CourseVariant'
+                required:
+                - data
+    post:
+      parameters:
+      - $ref: '#/components/parameters/CourseId'
+      summary: Create course variant
+      security:
+      - bearerAuth: []
+      tags:
+      - Org Courses
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateVariantRequest'
+      responses:
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+        "201":
+          description: Variant created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/CourseVariant'
+                required:
+                - data
+  /v1/org/courses/{courseId}/variants/{variantId}:
+    patch:
+      parameters:
+      - $ref: '#/components/parameters/CourseId'
+      - name: variantId
+        in: path
+        required: true
+        schema:
+          type: string
+      summary: Update course variant
+      security:
+      - bearerAuth: []
+      tags:
+      - Org Courses
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateVariantRequest'
+      responses:
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+        "200":
+          description: Variant updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/CourseVariant'
+                required:
+                - data
+    delete:
+      parameters:
+      - $ref: '#/components/parameters/CourseId'
+      - name: variantId
+        in: path
+        required: true
+        schema:
+          type: string
+      summary: Delete course variant
+      security:
+      - bearerAuth: []
+      tags:
+      - Org Courses
+      responses:
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+        "204":
+          description: Variant deleted
   /v1/public/{tenantCode}/courses/{courseId}/enrollments:
     post:
       parameters:

--- a/services/api/src/handlers/orgCourseVariantsCreate.ts
+++ b/services/api/src/handlers/orgCourseVariantsCreate.ts
@@ -1,0 +1,38 @@
+import type { APIGatewayProxyHandlerV2 } from "aws-lambda";
+import { writeAuditEvent } from "../lib/audit";
+import { authenticateRequest } from "../lib/auth";
+import { authorizeOrgAction } from "../lib/authorization";
+import { createCorrelationContext } from "../lib/correlation";
+import { createVariant, type CreateVariantInput } from "../lib/courses";
+import { ApiError } from "../lib/errors";
+import { errorResponse, jsonResponse } from "../lib/http";
+import { parseJsonBody } from "../lib/request";
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const correlation = createCorrelationContext(event.requestContext.requestId, event.headers);
+  try {
+    const auth = await authenticateRequest(event.headers);
+    authorizeOrgAction(auth, "ORG_COURSE_WRITE");
+
+    const courseId = event.pathParameters?.courseId;
+    if (!courseId) throw new ApiError(400, "VALIDATION_ERROR", "Missing courseId path parameter.");
+
+    const input = parseJsonBody<CreateVariantInput>(event);
+    const variant = await createVariant(auth.tenantId, courseId, auth.userId, input);
+
+    await writeAuditEvent({
+      tenantId: auth.tenantId,
+      actorUserId: auth.userId,
+      action: "course.variant.create",
+      resourceType: "course_variant",
+      resourceId: variant.id,
+      correlationId: correlation.correlationId,
+      requestId: correlation.requestId,
+      details: { courseId, variantId: variant.id, title: variant.title }
+    });
+
+    return jsonResponse(201, { data: variant }, correlation);
+  } catch (error) {
+    return errorResponse(error, correlation);
+  }
+};

--- a/services/api/src/handlers/orgCourseVariantsDelete.ts
+++ b/services/api/src/handlers/orgCourseVariantsDelete.ts
@@ -1,29 +1,39 @@
 import type { APIGatewayProxyHandlerV2 } from "aws-lambda";
+import { writeAuditEvent } from "../lib/audit";
 import { authenticateRequest } from "../lib/auth";
 import { authorizeOrgAction } from "../lib/authorization";
 import { createCorrelationContext } from "../lib/correlation";
-import { getCourse, listVariants } from "../lib/courses";
+import { deleteVariant } from "../lib/courses";
 import { ApiError } from "../lib/errors";
 import { errorResponse, jsonResponse } from "../lib/http";
-import { toOrgCourseView } from "../lib/orgViews";
 
 export const handler: APIGatewayProxyHandlerV2 = async (event) => {
   const correlation = createCorrelationContext(event.requestContext.requestId, event.headers);
   try {
     const auth = await authenticateRequest(event.headers);
-    authorizeOrgAction(auth, "ORG_COURSE_READ");
+    authorizeOrgAction(auth, "ORG_COURSE_WRITE");
 
     const courseId = event.pathParameters?.courseId;
     if (!courseId) throw new ApiError(400, "VALIDATION_ERROR", "Missing courseId path parameter.");
 
-    const [course, variants] = await Promise.all([
-      getCourse(auth.tenantId, courseId),
-      listVariants(auth.tenantId, courseId)
-    ]);
-    return jsonResponse(200, { data: { ...toOrgCourseView(course), variants } }, correlation);
+    const variantId = event.pathParameters?.variantId;
+    if (!variantId) throw new ApiError(400, "VALIDATION_ERROR", "Missing variantId path parameter.");
+
+    await deleteVariant(auth.tenantId, courseId, variantId);
+
+    await writeAuditEvent({
+      tenantId: auth.tenantId,
+      actorUserId: auth.userId,
+      action: "course.variant.delete",
+      resourceType: "course_variant",
+      resourceId: variantId,
+      correlationId: correlation.correlationId,
+      requestId: correlation.requestId,
+      details: { courseId, variantId }
+    });
+
+    return jsonResponse(204, {}, correlation);
   } catch (error) {
     return errorResponse(error, correlation);
   }
 };
-
-

--- a/services/api/src/handlers/orgCourseVariantsList.ts
+++ b/services/api/src/handlers/orgCourseVariantsList.ts
@@ -2,10 +2,9 @@ import type { APIGatewayProxyHandlerV2 } from "aws-lambda";
 import { authenticateRequest } from "../lib/auth";
 import { authorizeOrgAction } from "../lib/authorization";
 import { createCorrelationContext } from "../lib/correlation";
-import { getCourse, listVariants } from "../lib/courses";
+import { listVariants } from "../lib/courses";
 import { ApiError } from "../lib/errors";
 import { errorResponse, jsonResponse } from "../lib/http";
-import { toOrgCourseView } from "../lib/orgViews";
 
 export const handler: APIGatewayProxyHandlerV2 = async (event) => {
   const correlation = createCorrelationContext(event.requestContext.requestId, event.headers);
@@ -16,14 +15,9 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     const courseId = event.pathParameters?.courseId;
     if (!courseId) throw new ApiError(400, "VALIDATION_ERROR", "Missing courseId path parameter.");
 
-    const [course, variants] = await Promise.all([
-      getCourse(auth.tenantId, courseId),
-      listVariants(auth.tenantId, courseId)
-    ]);
-    return jsonResponse(200, { data: { ...toOrgCourseView(course), variants } }, correlation);
+    const variants = await listVariants(auth.tenantId, courseId);
+    return jsonResponse(200, { data: variants }, correlation);
   } catch (error) {
     return errorResponse(error, correlation);
   }
 };
-
-

--- a/services/api/src/handlers/orgCourseVariantsUpdate.ts
+++ b/services/api/src/handlers/orgCourseVariantsUpdate.ts
@@ -1,0 +1,41 @@
+import type { APIGatewayProxyHandlerV2 } from "aws-lambda";
+import { writeAuditEvent } from "../lib/audit";
+import { authenticateRequest } from "../lib/auth";
+import { authorizeOrgAction } from "../lib/authorization";
+import { createCorrelationContext } from "../lib/correlation";
+import { updateVariant, type UpdateVariantInput } from "../lib/courses";
+import { ApiError } from "../lib/errors";
+import { errorResponse, jsonResponse } from "../lib/http";
+import { parseJsonBody } from "../lib/request";
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const correlation = createCorrelationContext(event.requestContext.requestId, event.headers);
+  try {
+    const auth = await authenticateRequest(event.headers);
+    authorizeOrgAction(auth, "ORG_COURSE_WRITE");
+
+    const courseId = event.pathParameters?.courseId;
+    if (!courseId) throw new ApiError(400, "VALIDATION_ERROR", "Missing courseId path parameter.");
+
+    const variantId = event.pathParameters?.variantId;
+    if (!variantId) throw new ApiError(400, "VALIDATION_ERROR", "Missing variantId path parameter.");
+
+    const input = parseJsonBody<UpdateVariantInput>(event);
+    const variant = await updateVariant(auth.tenantId, courseId, variantId, auth.userId, input);
+
+    await writeAuditEvent({
+      tenantId: auth.tenantId,
+      actorUserId: auth.userId,
+      action: "course.variant.update",
+      resourceType: "course_variant",
+      resourceId: variantId,
+      correlationId: correlation.correlationId,
+      requestId: correlation.requestId,
+      details: { courseId, variantId }
+    });
+
+    return jsonResponse(200, { data: variant }, correlation);
+  } catch (error) {
+    return errorResponse(error, correlation);
+  }
+};

--- a/services/api/src/lib/audit.ts
+++ b/services/api/src/lib/audit.ts
@@ -7,6 +7,9 @@ export type AuditAction =
   | "course.create"
   | "course.publish"
   | "course.archive"
+  | "course.variant.create"
+  | "course.variant.update"
+  | "course.variant.delete"
   | "form.upsert"
   | "submission.create"
   | "submission.status_update"
@@ -23,7 +26,7 @@ export type AuditEventInput = {
   tenantId: string;
   actorUserId: string;
   action: AuditAction;
-  resourceType: "course" | "form" | "form_template" | "submission" | "branding" | "tenant";
+  resourceType: "course" | "course_variant" | "form" | "form_template" | "submission" | "branding" | "tenant";
   resourceId: string;
   correlationId: string;
   requestId: string;

--- a/services/api/src/lib/courses.ts
+++ b/services/api/src/lib/courses.ts
@@ -43,6 +43,39 @@ export type Course = {
   updatedBy: string;
 };
 
+export type CourseVariant = {
+  id: string;
+  courseId: string;
+  tenantId: string;
+  title: string;
+  description: string | null;
+  startDate: string;
+  endDate: string;
+  deliveryMode: DeliveryMode;
+  locationText: string | null;
+  capacity: number | null;
+  price: number | null;
+  displayOrder: number;
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+  updatedBy: string;
+};
+
+export type CreateVariantInput = {
+  title: string;
+  description?: string | null;
+  startDate: string;
+  endDate: string;
+  deliveryMode: DeliveryMode;
+  locationText?: string | null;
+  capacity?: number | null;
+  price?: number | null;
+  displayOrder?: number;
+};
+
+export type UpdateVariantInput = Partial<CreateVariantInput>;
+
 export type CreateCourseInput = {
   title: string;
   shortDescription: string;
@@ -98,6 +131,19 @@ export type PublicCoursesListResult = {
   };
 };
 
+export type PublicCourseVariant = {
+  id: string;
+  title: string;
+  description: string | null;
+  startDate: string;
+  endDate: string;
+  deliveryMode: DeliveryMode;
+  locationText: string | null;
+  capacity: number | null;
+  price: number | null;
+  displayOrder: number;
+};
+
 export type PublicCourseDetail = PublicCourse & {
   fullDescription: string;
   capacity: number | null;
@@ -107,6 +153,7 @@ export type PublicCourseDetail = PublicCourse & {
     version: number;
     fields: FormField[];
   } | null;
+  variants: PublicCourseVariant[];
 };
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
@@ -125,6 +172,8 @@ let testResolveTenantIdByCodeOverride: ((tenantCode: string) => Promise<string>)
 let testDdbSendOverride:
   | ((command: object) => Promise<unknown>)
   | null = null;
+let testListVariantsOverride: ((tenantId: string, courseId: string) => Promise<CourseVariant[]>) | null = null;
+let testGetVariantOverride: ((tenantId: string, courseId: string, variantId: string) => Promise<CourseVariant>) | null = null;
 
 async function sendDdb<TResult>(command: object): Promise<TResult> {
   if (testDdbSendOverride) {
@@ -143,6 +192,10 @@ function courseSk(courseId: string): string {
 
 function coursePublicSk(courseId: string): string {
   return `COURSE_PUBLIC#${courseId}`;
+}
+
+function variantSk(courseId: string, variantId: string): string {
+  return `COURSE#${courseId}#VARIANT#${variantId}`;
 }
 
 function tenantCodePk(tenantCode: string): string {
@@ -309,7 +362,10 @@ function isValidPublicProjection(item: Record<string, unknown>, tenantCode: stri
   return true;
 }
 
-async function publicCourseDetailFromItem(item: Record<string, unknown>): Promise<PublicCourseDetail> {
+async function publicCourseDetailFromItem(
+  item: Record<string, unknown>,
+  variants: PublicCourseVariant[] = []
+): Promise<PublicCourseDetail> {
   const activeFormVersion = Number.isInteger(item.activeFormVersion) ? (item.activeFormVersion as number) : null;
   let formSchema: { version: number; fields: FormField[] } | null = null;
 
@@ -333,7 +389,23 @@ async function publicCourseDetailFromItem(item: Record<string, unknown>): Promis
     capacity: (item.capacity as number | null) ?? null,
     formAvailable: Boolean(item.activeFormId) && activeFormVersion !== null && formSchema !== null,
     formVersion: formSchema?.version ?? activeFormVersion,
-    formSchema
+    formSchema,
+    variants
+  };
+}
+
+function variantToPublic(v: CourseVariant): PublicCourseVariant {
+  return {
+    id: v.id,
+    title: v.title,
+    description: v.description,
+    startDate: v.startDate,
+    endDate: v.endDate,
+    deliveryMode: v.deliveryMode,
+    locationText: v.locationText,
+    capacity: v.capacity,
+    price: v.price,
+    displayOrder: v.displayOrder
   };
 }
 
@@ -387,6 +459,167 @@ async function deletePublicProjection(tenantId: string, courseId: string): Promi
       Key: { PK: tenantPk(tenantId), SK: coursePublicSk(courseId) }
     })
   );
+}
+
+function variantFromItem(item: Record<string, unknown>): CourseVariant {
+  return {
+    id: item.variantId as string,
+    courseId: item.courseId as string,
+    tenantId: item.tenantId as string,
+    title: item.title as string,
+    description: (item.description as string | null) ?? null,
+    startDate: item.startDate as string,
+    endDate: item.endDate as string,
+    deliveryMode: item.deliveryMode as DeliveryMode,
+    locationText: (item.locationText as string | null) ?? null,
+    capacity: (item.capacity as number | null) ?? null,
+    price: (item.price as number | null) ?? null,
+    displayOrder: (item.displayOrder as number) ?? 0,
+    createdAt: item.createdAt as string,
+    updatedAt: item.updatedAt as string,
+    createdBy: item.createdBy as string,
+    updatedBy: item.updatedBy as string
+  };
+}
+
+function validateCreateVariant(input: CreateVariantInput): void {
+  if (!input.title?.trim()) throw new ApiError(400, "VALIDATION_ERROR", "title is required.");
+  if (!input.startDate) throw new ApiError(400, "VALIDATION_ERROR", "startDate is required.");
+  if (!input.endDate) throw new ApiError(400, "VALIDATION_ERROR", "endDate is required.");
+  if (!input.deliveryMode) throw new ApiError(400, "VALIDATION_ERROR", "deliveryMode is required.");
+}
+
+export async function createVariant(
+  tenantId: string,
+  courseId: string,
+  userId: string,
+  input: CreateVariantInput
+): Promise<CourseVariant> {
+  validateCreateVariant(input);
+  await getCourse(tenantId, courseId);
+  const now = new Date().toISOString();
+  const id = `var_${randomUUID().replace(/-/g, "").slice(0, 16)}`;
+  const displayOrder = input.displayOrder ?? 0;
+
+  const item = {
+    PK: tenantPk(tenantId),
+    SK: variantSk(courseId, id),
+    entityType: "COURSE_VARIANT",
+    tenantId,
+    courseId,
+    variantId: id,
+    title: input.title.trim(),
+    description: input.description?.trim() ?? null,
+    startDate: input.startDate,
+    endDate: input.endDate,
+    deliveryMode: input.deliveryMode,
+    locationText: input.locationText ?? null,
+    capacity: input.capacity ?? null,
+    price: input.price ?? null,
+    displayOrder,
+    createdAt: now,
+    updatedAt: now,
+    createdBy: userId,
+    updatedBy: userId
+  };
+
+  await sendDdb(
+    new PutCommand({
+      TableName: tableName,
+      Item: item,
+      ConditionExpression: "attribute_not_exists(PK) AND attribute_not_exists(SK)"
+    })
+  );
+
+  return variantFromItem(item);
+}
+
+export async function listVariants(tenantId: string, courseId: string): Promise<CourseVariant[]> {
+  if (testListVariantsOverride) {
+    return testListVariantsOverride(tenantId, courseId);
+  }
+  const out = await sendDdb<{ Items?: unknown[] }>(
+    new QueryCommand({
+      TableName: tableName,
+      KeyConditionExpression: "PK = :pk AND begins_with(SK, :sk)",
+      ExpressionAttributeValues: {
+        ":pk": tenantPk(tenantId),
+        ":sk": `COURSE#${courseId}#VARIANT#`
+      }
+    })
+  );
+  return (out.Items ?? [])
+    .map((i) => variantFromItem(i as Record<string, unknown>))
+    .sort((a, b) => a.displayOrder - b.displayOrder || a.createdAt.localeCompare(b.createdAt));
+}
+
+export async function getVariant(tenantId: string, courseId: string, variantId: string): Promise<CourseVariant> {
+  if (testGetVariantOverride) {
+    return testGetVariantOverride(tenantId, courseId, variantId);
+  }
+  const out = await sendDdb<{ Item?: Record<string, unknown> }>(
+    new GetCommand({
+      TableName: tableName,
+      Key: { PK: tenantPk(tenantId), SK: variantSk(courseId, variantId) }
+    })
+  );
+  if (!out.Item) throw new ApiError(404, "NOT_FOUND", "Variant not found.");
+  return variantFromItem(out.Item as Record<string, unknown>);
+}
+
+export async function updateVariant(
+  tenantId: string,
+  courseId: string,
+  variantId: string,
+  userId: string,
+  input: UpdateVariantInput
+): Promise<CourseVariant> {
+  const entries = Object.entries(input).filter(([, value]) => value !== undefined);
+  if (entries.length === 0) {
+    throw new ApiError(400, "VALIDATION_ERROR", "No fields provided for update.");
+  }
+
+  const exprNames: Record<string, string> = { "#updatedAt": "updatedAt", "#updatedBy": "updatedBy" };
+  const exprValues: Record<string, unknown> = {
+    ":updatedAt": new Date().toISOString(),
+    ":updatedBy": userId
+  };
+  const updates: string[] = ["#updatedAt = :updatedAt", "#updatedBy = :updatedBy"];
+
+  for (const [key, value] of entries) {
+    const nk = `#${key}`;
+    const vk = `:${key}`;
+    exprNames[nk] = key;
+    exprValues[vk] = value;
+    updates.push(`${nk} = ${vk}`);
+  }
+
+  const out = await sendDdb<{ Attributes?: Record<string, unknown> }>(
+    new UpdateCommand({
+      TableName: tableName,
+      Key: { PK: tenantPk(tenantId), SK: variantSk(courseId, variantId) },
+      ConditionExpression: "attribute_exists(PK) AND attribute_exists(SK)",
+      UpdateExpression: `SET ${updates.join(", ")}`,
+      ExpressionAttributeNames: exprNames,
+      ExpressionAttributeValues: exprValues,
+      ReturnValues: "ALL_NEW"
+    })
+  );
+
+  if (!out.Attributes) throw new ApiError(404, "NOT_FOUND", "Variant not found.");
+  return variantFromItem(out.Attributes as Record<string, unknown>);
+}
+
+export async function deleteVariant(tenantId: string, courseId: string, variantId: string): Promise<void> {
+  const out = await sendDdb<{ Attributes?: Record<string, unknown> }>(
+    new DeleteCommand({
+      TableName: tableName,
+      Key: { PK: tenantPk(tenantId), SK: variantSk(courseId, variantId) },
+      ConditionExpression: "attribute_exists(PK) AND attribute_exists(SK)",
+      ReturnValues: "ALL_OLD"
+    })
+  );
+  if (!out.Attributes) throw new ApiError(404, "NOT_FOUND", "Variant not found.");
 }
 
 function validateCreate(input: CreateCourseInput): void {
@@ -773,7 +1006,9 @@ export async function getPublicCourseDetail(
   if (!isValidPublicProjection(item, normalizedTenantCode)) {
     throw new ApiError(404, "NOT_FOUND", "Course not found.");
   }
-  return publicCourseDetailFromItem(item);
+  const variants = await listVariants(tenantId, courseId);
+  const publicVariants = variants.map(variantToPublic);
+  return publicCourseDetailFromItem(item, publicVariants);
 }
 
 export async function reconcilePublicProjectionsForTenant(
@@ -824,6 +1059,14 @@ export const __coursesTestHooks = {
   setResolveTenantIdByCodeOverride(loader: ((tenantCode: string) => Promise<string>) | null): void {
     testResolveTenantIdByCodeOverride = loader;
   },
+  setListVariantsOverride(loader: ((tenantId: string, courseId: string) => Promise<CourseVariant[]>) | null): void {
+    testListVariantsOverride = loader;
+  },
+  setGetVariantOverride(
+    loader: ((tenantId: string, courseId: string, variantId: string) => Promise<CourseVariant>) | null
+  ): void {
+    testGetVariantOverride = loader;
+  },
   setDdbSendOverride(loader: ((command: object) => Promise<unknown>) | null): void {
     testDdbSendOverride = loader;
   },
@@ -833,6 +1076,8 @@ export const __coursesTestHooks = {
     testPublicCoursesListOverride = null;
     testPublicCourseDetailOverride = null;
     testResolveTenantIdByCodeOverride = null;
+    testListVariantsOverride = null;
+    testGetVariantOverride = null;
     testDdbSendOverride = null;
   }
 };

--- a/services/api/src/lib/submissions.ts
+++ b/services/api/src/lib/submissions.ts
@@ -8,7 +8,7 @@ import {
   TransactWriteCommand,
   UpdateCommand
 } from "@aws-sdk/lib-dynamodb";
-import { getPublicCourseDetail, getVariant, listVariants, resolveTenantIdByCode } from "./courses";
+import { getPublicCourseDetail, resolveTenantIdByCode } from "./courses";
 import { ApiError } from "./errors";
 import { type FormField, type FormFieldType, getCourseFormSchemaVersion } from "./formSchemas";
 
@@ -611,14 +611,18 @@ export async function createPublicEnrollment(
     throw new ApiError(409, "CONFLICT", "Enrollment window is closed.");
   }
 
-  // Validate variantId when variants exist for this course
-  const variants = await listVariants(tenantId, courseId);
+  // Validate variantId using the variants already embedded in the public course detail.
+  // This avoids extra DDB round-trips and keeps the check within the submissions sendDdb boundary.
+  const courseVariants = publicCourse.variants ?? [];
   let resolvedVariantId: string | null = null;
-  if (variants.length > 0) {
+  if (courseVariants.length > 0) {
     if (!input.variantId) {
       throw new ApiError(400, "VALIDATION_ERROR", "variantId is required when the course has variants.");
     }
-    await getVariant(tenantId, courseId, input.variantId);
+    const variantExists = courseVariants.some((v) => v.id === input.variantId);
+    if (!variantExists) {
+      throw new ApiError(400, "VALIDATION_ERROR", "variantId is not valid for this course.");
+    }
     resolvedVariantId = input.variantId;
   } else if (input.variantId) {
     throw new ApiError(400, "VALIDATION_ERROR", "variantId is not valid for this course.");

--- a/services/api/src/lib/submissions.ts
+++ b/services/api/src/lib/submissions.ts
@@ -8,7 +8,7 @@ import {
   TransactWriteCommand,
   UpdateCommand
 } from "@aws-sdk/lib-dynamodb";
-import { getPublicCourseDetail, resolveTenantIdByCode } from "./courses";
+import { getPublicCourseDetail, getVariant, listVariants, resolveTenantIdByCode } from "./courses";
 import { ApiError } from "./errors";
 import { type FormField, type FormFieldType, getCourseFormSchemaVersion } from "./formSchemas";
 
@@ -24,6 +24,7 @@ export type Submission = {
   tenantId: string;
   tenantCode: string;
   courseId: string;
+  variantId: string | null;
   formId: string;
   formVersion: number;
   status: SubmissionStatus;
@@ -69,6 +70,7 @@ export type CreateEnrollmentInput = {
   formVersion: number;
   answers: Record<string, unknown>;
   meta?: EnrollmentMeta;
+  variantId?: string | null;
 };
 
 export type EnrollmentCreateResult = {
@@ -175,6 +177,7 @@ function submissionFromItem(item: Record<string, unknown>): Submission {
     tenantId: item.tenantId as string,
     tenantCode: item.tenantCode as string,
     courseId: item.courseId as string,
+    variantId: (item.variantId as string | null) ?? null,
     formId: item.formId as string,
     formVersion: item.formVersion as number,
     status: item.status as SubmissionStatus,
@@ -608,6 +611,19 @@ export async function createPublicEnrollment(
     throw new ApiError(409, "CONFLICT", "Enrollment window is closed.");
   }
 
+  // Validate variantId when variants exist for this course
+  const variants = await listVariants(tenantId, courseId);
+  let resolvedVariantId: string | null = null;
+  if (variants.length > 0) {
+    if (!input.variantId) {
+      throw new ApiError(400, "VALIDATION_ERROR", "variantId is required when the course has variants.");
+    }
+    await getVariant(tenantId, courseId, input.variantId);
+    resolvedVariantId = input.variantId;
+  } else if (input.variantId) {
+    throw new ApiError(400, "VALIDATION_ERROR", "variantId is not valid for this course.");
+  }
+
   const schema = await getCourseFormSchemaVersion(tenantId, courseId, input.formVersion);
 
   // BS-04: strip HTML tags from free-text answers before validation or storage
@@ -626,6 +642,7 @@ export async function createPublicEnrollment(
   const requestHash = hashRequest({
     tenantCode: tenantCode.trim().toLowerCase(),
     courseId,
+    variantId: resolvedVariantId,
     formVersion: input.formVersion,
     answers: sanitizedAnswers,
     meta: input.meta ?? null
@@ -655,6 +672,7 @@ export async function createPublicEnrollment(
     tenantCode: tenantCode.trim().toLowerCase(),
     submissionId,
     courseId,
+    variantId: resolvedVariantId,
     formId: schema.formId,
     formVersion: schema.version,
     status: "submitted",

--- a/tests/orgPortalContracts.integration.test.ts
+++ b/tests/orgPortalContracts.integration.test.ts
@@ -212,6 +212,7 @@ test("orgSubmissionsList adds course title and review workflow metadata", async 
         submittedAt: "2026-03-20T00:00:00Z",
         reviewedAt: null,
         reviewedBy: null,
+        variantId: null,
         createdAt: "2026-03-20T00:00:00Z",
         applicantSummary: { email: "learner@example.com", name: "Learner" },
         course: { id: "crs_1" }

--- a/tests/publicPortalPayloads.integration.test.ts
+++ b/tests/publicPortalPayloads.integration.test.ts
@@ -220,7 +220,8 @@ test("public course detail includes form availability and capacity", async () =>
           displayOrder: 1
         }
       ]
-    }
+    },
+    variants: []
   }));
 
   const event = {
@@ -356,6 +357,11 @@ test("public course detail resolves signed image URLs from legacy stored imageUr
           activeFormVersion: 1
         }
       };
+    }
+    // Handle listVariants query (returns no variants for this test)
+    const cmd = command as { input?: { KeyConditionExpression?: string; ExpressionAttributeValues?: Record<string, unknown> } };
+    if (cmd.input?.ExpressionAttributeValues?.[":sk"] === "COURSE#crs_legacy#VARIANT#") {
+      return { Items: [] };
     }
     throw new Error("Unexpected DDB command.");
   });

--- a/tests/submissions.unit.test.ts
+++ b/tests/submissions.unit.test.ts
@@ -49,7 +49,8 @@ test("createPublicEnrollment uses a single transaction for idempotency and submi
     formSchema: {
       version: 1,
       fields: []
-    }
+    },
+    variants: []
   }));
   __formSchemasTestHooks.setGetCourseFormSchemaVersionOverride(async () => ({
     formId: "frm_001",
@@ -123,7 +124,8 @@ test("createPublicEnrollment persists applicant identity derived from schema ans
     formSchema: {
       version: 1,
       fields: []
-    }
+    },
+    variants: []
   }));
   __formSchemasTestHooks.setGetCourseFormSchemaVersionOverride(async () => ({
     formId: "frm_001",
@@ -217,7 +219,8 @@ test("createPublicEnrollment replays prior success when transaction collides on 
     formSchema: {
       version: 1,
       fields: []
-    }
+    },
+    variants: []
   }));
   __formSchemasTestHooks.setGetCourseFormSchemaVersionOverride(async () => ({
     formId: "frm_001",
@@ -315,7 +318,8 @@ test("createPublicEnrollment rejects reused idempotency key when the prior reque
     formSchema: {
       version: 1,
       fields: []
-    }
+    },
+    variants: []
   }));
   __formSchemasTestHooks.setGetCourseFormSchemaVersionOverride(async () => ({
     formId: "frm_001",


### PR DESCRIPTION
## Summary

- Courses can now have multiple **variants** (e.g. different class times, online vs onsite, morning vs evening). Variants share the parent course's form and quote but carry their own schedule, delivery details, description, and a reserved `price` field.
- Enrollment validates `variantId`: required when the course has variants, rejected when it has none.
- Courses without variants behave exactly as before (no breaking changes).

## Changes

**Data layer (`courses.ts`)**
- `CourseVariant` type + DynamoDB key helpers (`variantSk`)
- `createVariant`, `listVariants`, `getVariant`, `updateVariant`, `deleteVariant` lib functions
- `getPublicCourseDetail` now fetches and embeds variants in the public projection

**Submissions (`submissions.ts`)**
- `variantId: string | null` added to `Submission`
- `createPublicEnrollment` validates variant presence/absence at runtime

**Audit (`audit.ts`)**
- `course.variant.create`, `course.variant.update`, `course.variant.delete` actions added
- `course_variant` resource type added

**Handlers (new)**
- `POST /v1/org/courses/{courseId}/variants` — create variant
- `GET /v1/org/courses/{courseId}/variants` — list variants
- `PATCH /v1/org/courses/{courseId}/variants/{variantId}` — update variant
- `DELETE /v1/org/courses/{courseId}/variants/{variantId}` — delete variant

**Existing handler updates**
- `orgCoursesGet`: includes `variants` array in response

**Infrastructure**
- 4 new Lambda functions + API Gateway routes in `infra/template.yaml`

**Spec**
- `CourseVariant` and `PublicCourseVariant` schemas added to `openapi.yaml`
- Enrollment request body updated with optional `variantId`

## Test plan

- [x] `npm test` — 152 pass, 0 fail
- [x] `tsc --noEmit` — no errors
- [ ] Deploy and verify: create a course → add 2 variants → publish → enroll via public portal with variant selected → confirm `variantId` on submission record
- [ ] Regression: course without variants → enrollment flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)