### PR TITLE
fix: replace tenant profile table scan with GSI1 query

### DIFF
--- a/scripts/backfill-tenant-profile-gsi.js
+++ b/scripts/backfill-tenant-profile-gsi.js
@@ -1,0 +1,91 @@
+/* eslint-disable no-console */
+/**
+ * Backfills GSI1PK / GSI1SK onto existing TENANT PROFILE items so they can be
+ * queried via the GSI1 index instead of a full-table scan.
+ *
+ * Usage:
+ *   node scripts/backfill-tenant-profile-gsi.js              # dry run (default)
+ *   MIGRATION_DRY_RUN=false node scripts/backfill-tenant-profile-gsi.js
+ */
+const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
+const { DynamoDBDocumentClient, ScanCommand, UpdateCommand } = require("@aws-sdk/lib-dynamodb");
+
+const tableName = process.env.ONLINEFORMS_TABLE || "OnlineFormsMain";
+const dryRun = (process.env.MIGRATION_DRY_RUN || "true").toLowerCase() !== "false";
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+const TENANT_PROFILE_GSI1PK = "ENTITY_TYPE#TENANT";
+
+async function scanTenantProfiles() {
+  const items = [];
+  let lastKey;
+  do {
+    const out = await ddb.send(
+      new ScanCommand({
+        TableName: tableName,
+        FilterExpression: "#sk = :profileSk AND #entityType = :entityType",
+        ExpressionAttributeNames: {
+          "#sk": "SK",
+          "#entityType": "entityType"
+        },
+        ExpressionAttributeValues: {
+          ":profileSk": "PROFILE",
+          ":entityType": "TENANT"
+        },
+        ExclusiveStartKey: lastKey
+      })
+    );
+    items.push(...(out.Items ?? []));
+    lastKey = out.LastEvaluatedKey;
+  } while (lastKey);
+  return items;
+}
+
+async function main() {
+  console.log(`Mode: ${dryRun ? "DRY RUN" : "LIVE"}`);
+  console.log(`Table: ${tableName}`);
+
+  const profiles = await scanTenantProfiles();
+  console.log(`Found ${profiles.length} TENANT PROFILE item(s)`);
+
+  let skipped = 0;
+  let updated = 0;
+
+  for (const item of profiles) {
+    const { PK, SK, tenantId, GSI1PK } = item;
+
+    if (GSI1PK === TENANT_PROFILE_GSI1PK) {
+      console.log(`  SKIP  ${tenantId} — GSI keys already present`);
+      skipped++;
+      continue;
+    }
+
+    console.log(`  ${dryRun ? "WOULD UPDATE" : "UPDATE"} ${tenantId} (PK=${PK})`);
+
+    if (!dryRun) {
+      await ddb.send(
+        new UpdateCommand({
+          TableName: tableName,
+          Key: { PK, SK },
+          UpdateExpression: "SET GSI1PK = :gsi1pk, GSI1SK = :gsi1sk",
+          ExpressionAttributeValues: {
+            ":gsi1pk": TENANT_PROFILE_GSI1PK,
+            ":gsi1sk": tenantId
+          },
+          ConditionExpression: "attribute_exists(PK) AND attribute_exists(SK)"
+        })
+      );
+    }
+    updated++;
+  }
+
+  console.log(`\nDone. ${updated} updated, ${skipped} skipped.`);
+  if (dryRun) {
+    console.log("Re-run with MIGRATION_DRY_RUN=false to apply changes.");
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/services/api/src/lib/tenants.ts
+++ b/services/api/src/lib/tenants.ts
@@ -3,7 +3,7 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
   DynamoDBDocumentClient,
   GetCommand,
-  ScanCommand,
+  QueryCommand,
   TransactWriteCommand,
   UpdateCommand
 } from "@aws-sdk/lib-dynamodb";
@@ -86,6 +86,7 @@ export type CreateTenantProfileInput = {
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const tableName = process.env.ONLINEFORMS_TABLE ?? "OnlineFormsMain";
+const TENANT_PROFILE_GSI1PK = "ENTITY_TYPE#TENANT";
 const MAX_DISPLAY_NAME_LENGTH = 120;
 const MAX_DESCRIPTION_LENGTH = 500;
 const MAX_HOME_PAGE_CONTENT_LENGTH = 8000;
@@ -359,28 +360,34 @@ export async function getTenantProfile(tenantId: string): Promise<TenantProfile>
   return toTenantProfile(tenantId, out.Item as Record<string, unknown>);
 }
 
+async function queryAllTenantProfiles(): Promise<Record<string, unknown>[]> {
+  const rows: Record<string, unknown>[] = [];
+  let lastKey: Record<string, unknown> | undefined;
+  do {
+    const out = await ddb.send(
+      new QueryCommand({
+        TableName: tableName,
+        IndexName: "GSI1",
+        KeyConditionExpression: "GSI1PK = :gsi1pk",
+        ExpressionAttributeValues: {
+          ":gsi1pk": TENANT_PROFILE_GSI1PK
+        },
+        ExclusiveStartKey: lastKey
+      })
+    );
+    for (const item of out.Items ?? []) {
+      rows.push(item as Record<string, unknown>);
+    }
+    lastKey = out.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (lastKey);
+  return rows;
+}
+
 export async function listPublicTenantDirectory(limit = 50): Promise<PublicTenantDirectoryItem[]> {
   if (testPublicTenantDirectoryOverride) {
     return testPublicTenantDirectoryOverride(limit);
   }
-  const normalizedLimit = Number.isInteger(limit) && limit > 0 ? Math.min(limit, 100) : 50;
-  const out = await ddb.send(
-    new ScanCommand({
-      TableName: tableName,
-      FilterExpression: "#sk = :profileSk AND #entityType = :entityType",
-      ExpressionAttributeNames: {
-        "#sk": "SK",
-        "#entityType": "entityType"
-      },
-      ExpressionAttributeValues: {
-        ":profileSk": "PROFILE",
-        ":entityType": "TENANT"
-      },
-      Limit: normalizedLimit
-    })
-  );
-
-  const rows = (out.Items ?? []).map((item) => item as Record<string, unknown>);
+  const rows = await queryAllTenantProfiles();
   const items = await Promise.all(
     rows.map(async (item) => {
       const tenantId = asString(item.tenantId);
@@ -443,24 +450,7 @@ export async function getPublicTenantHomeByCode(tenantCode: string): Promise<Pub
 }
 
 export async function listInternalTenantProfiles(limit = 100): Promise<TenantProfile[]> {
-  const normalizedLimit = Number.isInteger(limit) && limit > 0 ? Math.min(limit, 200) : 100;
-  const out = await ddb.send(
-    new ScanCommand({
-      TableName: tableName,
-      FilterExpression: "#sk = :profileSk AND #entityType = :entityType",
-      ExpressionAttributeNames: {
-        "#sk": "SK",
-        "#entityType": "entityType"
-      },
-      ExpressionAttributeValues: {
-        ":profileSk": "PROFILE",
-        ":entityType": "TENANT"
-      },
-      Limit: normalizedLimit
-    })
-  );
-
-  const rows = (out.Items ?? []).map((item) => item as Record<string, unknown>);
+  const rows = await queryAllTenantProfiles();
   return rows
     .map((item) => {
       const tenantId = asString(item.tenantId);
@@ -629,6 +619,8 @@ export async function createTenantProfile(input: CreateTenantProfileInput): Prom
   const profileItem = {
     PK: tenantPk(tenantId),
     SK: "PROFILE",
+    GSI1PK: TENANT_PROFILE_GSI1PK,
+    GSI1SK: tenantId,
     entityType: "TENANT",
     tenantId,
     tenantCode: normalized.tenantCode,


### PR DESCRIPTION
## Summary
- `listPublicTenantDirectory` and `listInternalTenantProfiles` used `ScanCommand` with a `Limit` that caps items *evaluated* (not returned), silently dropping tenants outside the scan window — causing the login dropdown to show raw tenant IDs (e.g. `ten_59c62f610a5b`) instead of display names
- Added `GSI1PK = "ENTITY_TYPE#TENANT"` / `GSI1SK = tenantId` to `TENANT PROFILE` items (sparse GSI pattern on existing GSI1) so all tenant profiles can be retrieved via a paginated `QueryCommand`
- Replaced both scan functions with a shared `queryAllTenantProfiles()` helper that queries GSI1 and paginates via `LastEvaluatedKey`

## Data fix
Backfill script (`scripts/backfill-tenant-profile-gsi.js`) has already been run against production — both existing tenant records updated and verified via direct GSI1 query.

## Test plan
- [x] 161/161 tests passing
- [x] TypeScript typecheck clean
- [x] GSI1 query confirmed returning both tenants with correct `displayName` and `tenantCode`
- [ ] Verify login dropdown shows "Southern Tourism & Hospitality Academy (stz-school)" for `ten_59c62f610a5b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)