### PR TITLE
feature: Stripe Connect destination charges with application fee

### DIFF
--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -1317,6 +1317,42 @@ Resources:
             Path: /internal/tenants/{tenantId}
             Method: PATCH
 
+  InternalTenantPaymentSettingsGetFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../deploy/lambda.zip
+      Handler: dist/services/api/src/handlers/internalTenantPaymentSettingsGet.handler
+      Policies:
+        - DynamoDBReadPolicy:
+            TableName: !Ref OnlineFormsMainTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref OnlineFormsAuthTable
+      Events:
+        InternalTenantPaymentSettingsGetRoute:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref OnlineFormsHttpApi
+            Path: /internal/tenants/{tenantId}/payment-settings
+            Method: GET
+
+  InternalTenantPaymentSettingsUpdateFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../deploy/lambda.zip
+      Handler: dist/services/api/src/handlers/internalTenantPaymentSettingsUpdate.handler
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref OnlineFormsMainTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref OnlineFormsAuthTable
+      Events:
+        InternalTenantPaymentSettingsUpdateRoute:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref OnlineFormsHttpApi
+            Path: /internal/tenants/{tenantId}/payment-settings
+            Method: PATCH
+
   InternalUsersListFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/services/api/src/handlers/internalTenantPaymentSettingsGet.ts
+++ b/services/api/src/handlers/internalTenantPaymentSettingsGet.ts
@@ -1,0 +1,38 @@
+import type { APIGatewayProxyHandlerV2 } from "aws-lambda";
+import { authenticateRequest } from "../lib/auth";
+import { authorizeOrgAction } from "../lib/authorization";
+import { createCorrelationContext } from "../lib/correlation";
+import { ApiError } from "../lib/errors";
+import { errorResponse, jsonResponse } from "../lib/http";
+import { getTenantProfile } from "../lib/tenants";
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const correlation = createCorrelationContext(event.requestContext.requestId, event.headers);
+  try {
+    const tenantId = event.pathParameters?.tenantId?.trim();
+    if (!tenantId) {
+      throw new ApiError(400, "VALIDATION_ERROR", "Missing tenantId path parameter.");
+    }
+
+    const auth = await authenticateRequest(event.headers, {
+      requireMembership: false,
+      allowMissingTenantContext: true
+    });
+    authorizeOrgAction(auth, "INTERNAL_TENANT_READ");
+
+    const profile = await getTenantProfile(tenantId);
+    return jsonResponse(
+      200,
+      {
+        data: {
+          currency: profile.currency,
+          stripeAccountId: profile.stripeAccountId,
+          applicationFeePercent: profile.applicationFeePercent
+        }
+      },
+      correlation
+    );
+  } catch (error) {
+    return errorResponse(error, correlation);
+  }
+};

--- a/services/api/src/handlers/internalTenantPaymentSettingsUpdate.ts
+++ b/services/api/src/handlers/internalTenantPaymentSettingsUpdate.ts
@@ -1,0 +1,74 @@
+import type { APIGatewayProxyHandlerV2 } from "aws-lambda";
+import { writeAuditEvent } from "../lib/audit";
+import { authenticateRequest } from "../lib/auth";
+import { authorizeOrgAction } from "../lib/authorization";
+import { createCorrelationContext } from "../lib/correlation";
+import { ApiError } from "../lib/errors";
+import { errorResponse, jsonResponse } from "../lib/http";
+import { parseJsonBody } from "../lib/request";
+import { getTenantProfile, updateTenantProfile } from "../lib/tenants";
+
+type UpdateInternalPaymentSettingsBody = {
+  stripeAccountId?: string | null;
+  applicationFeePercent?: number | null;
+};
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+  const correlation = createCorrelationContext(event.requestContext.requestId, event.headers);
+  try {
+    const tenantId = event.pathParameters?.tenantId?.trim();
+    if (!tenantId) {
+      throw new ApiError(400, "VALIDATION_ERROR", "Missing tenantId path parameter.");
+    }
+
+    const auth = await authenticateRequest(event.headers, {
+      requireMembership: false,
+      allowMissingTenantContext: true
+    });
+    authorizeOrgAction(auth, "INTERNAL_TENANT_WRITE");
+
+    const body = parseJsonBody<UpdateInternalPaymentSettingsBody>(event);
+
+    const hasStripeAccountId = Object.prototype.hasOwnProperty.call(body, "stripeAccountId");
+    const hasApplicationFeePercent = Object.prototype.hasOwnProperty.call(body, "applicationFeePercent");
+
+    if (!hasStripeAccountId && !hasApplicationFeePercent) {
+      throw new ApiError(400, "VALIDATION_ERROR", "At least one field (stripeAccountId, applicationFeePercent) must be provided.");
+    }
+
+    await updateTenantProfile(tenantId, {
+      ...(hasStripeAccountId ? { stripeAccountId: body.stripeAccountId ?? null } : {}),
+      ...(hasApplicationFeePercent ? { applicationFeePercent: body.applicationFeePercent ?? null } : {})
+    });
+
+    const profile = await getTenantProfile(tenantId);
+
+    await writeAuditEvent({
+      tenantId,
+      actorUserId: auth.userId,
+      action: "payment_settings.internal_update",
+      resourceType: "payment_settings",
+      resourceId: tenantId,
+      correlationId: correlation.correlationId,
+      requestId: correlation.requestId,
+      details: {
+        ...(hasStripeAccountId ? { stripeAccountId: profile.stripeAccountId } : {}),
+        ...(hasApplicationFeePercent ? { applicationFeePercent: profile.applicationFeePercent } : {})
+      }
+    });
+
+    return jsonResponse(
+      200,
+      {
+        data: {
+          currency: profile.currency,
+          stripeAccountId: profile.stripeAccountId,
+          applicationFeePercent: profile.applicationFeePercent
+        }
+      },
+      correlation
+    );
+  } catch (error) {
+    return errorResponse(error, correlation);
+  }
+};

--- a/services/api/src/handlers/orgSubmissionsRefund.ts
+++ b/services/api/src/handlers/orgSubmissionsRefund.ts
@@ -31,7 +31,11 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
       throw new ApiError(409, "CONFLICT", `Cannot refund a payment with status "${payment.status}".`);
     }
 
-    const refund = await createStripeRefund(payment.stripePaymentIntentId);
+    const isConnectCharge = payment.stripeAccountId != null;
+    const refund = await createStripeRefund(payment.stripePaymentIntentId, {
+      reverseTransfer: isConnectCharge,
+      refundApplicationFee: isConnectCharge && payment.applicationFeeAmount != null
+    });
 
     await updatePaymentRecord(auth.tenantId, payment.id, {
       status: "refunded",

--- a/services/api/src/handlers/publicCoursesPaymentIntentCreate.ts
+++ b/services/api/src/handlers/publicCoursesPaymentIntentCreate.ts
@@ -46,13 +46,15 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
       throw new ApiError(400, "VALIDATION_ERROR", "This variant does not have a price. Use the free enrollment flow.");
     }
 
-    // Fetch tenant currency.
+    // Fetch tenant payment configuration.
     const tenantProfile = await getTenantProfile(tenantId);
-    if (!tenantProfile.currency) {
+    if (!tenantProfile.currency || !tenantProfile.stripeAccountId) {
       throw new ApiError(503, "PAYMENT_NOT_CONFIGURED", "Payment is not configured for this organisation.");
     }
 
-    // Create Stripe PaymentIntent.
+    const applicationFeeAmount = Math.round(amount * (tenantProfile.applicationFeePercent ?? 0) / 100);
+
+    // Create Stripe PaymentIntent (destination charge to connected account).
     const { id: stripePaymentIntentId, clientSecret } = await createStripePaymentIntent(
       amount,
       tenantProfile.currency,
@@ -61,7 +63,9 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
         tenantCode,
         courseId,
         variantId: body.variantId
-      }
+      },
+      tenantProfile.stripeAccountId,
+      applicationFeeAmount
     );
 
     // Write pending payment record.
@@ -71,7 +75,9 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
       variantId: body.variantId,
       amount,
       currency: tenantProfile.currency,
-      stripePaymentIntentId
+      stripePaymentIntentId,
+      stripeAccountId: tenantProfile.stripeAccountId,
+      applicationFeeAmount
     });
 
     return jsonResponse(201, {

--- a/services/api/src/lib/audit.ts
+++ b/services/api/src/lib/audit.ts
@@ -23,7 +23,8 @@ export type AuditAction =
   | "form_template.delete"
   | "payment.create"
   | "payment.refund"
-  | "payment_settings.update";
+  | "payment_settings.update"
+  | "payment_settings.internal_update";
 
 export type AuditEventInput = {
   tenantId: string;

--- a/services/api/src/lib/payments.ts
+++ b/services/api/src/lib/payments.ts
@@ -43,6 +43,8 @@ export type CreatePaymentRecordInput = {
   amount: number;
   currency: string;
   stripePaymentIntentId: string;
+  stripeAccountId: string;
+  applicationFeeAmount: number;
 };
 
 export type RefundResult = {
@@ -114,7 +116,7 @@ async function getStripe(): Promise<StripeInstance> {
 
 let testDdbSendOverride: ((command: object) => Promise<Record<string, unknown>>) | null = null;
 let testStripeOverride: {
-  createPaymentIntent?: (amount: number, currency: string, metadata: Record<string, string>) => Promise<{ id: string; client_secret: string }>;
+  createPaymentIntent?: (amount: number, currency: string, metadata: Record<string, string>, stripeAccountId: string, applicationFeeAmount: number) => Promise<{ id: string; client_secret: string }>;
   retrievePaymentIntent?: (id: string) => Promise<{ id: string; status: string; latest_charge: string | null }>;
   createRefund?: (paymentIntentId: string) => Promise<{ id: string; amount: number; currency: string }>;
 } | null = null;
@@ -177,10 +179,12 @@ function fromItem(item: Record<string, unknown>): Payment {
 export async function createStripePaymentIntent(
   amount: number,
   currency: string,
-  metadata: Record<string, string>
+  metadata: Record<string, string>,
+  stripeAccountId: string,
+  applicationFeeAmount: number
 ): Promise<{ id: string; clientSecret: string }> {
   if (testStripeOverride?.createPaymentIntent) {
-    const result = await testStripeOverride.createPaymentIntent(amount, currency, metadata);
+    const result = await testStripeOverride.createPaymentIntent(amount, currency, metadata, stripeAccountId, applicationFeeAmount);
     return { id: result.id, clientSecret: result.client_secret };
   }
   const stripe = await getStripe();
@@ -188,7 +192,9 @@ export async function createStripePaymentIntent(
     amount,
     currency,
     metadata,
-    automatic_payment_methods: { enabled: true }
+    automatic_payment_methods: { enabled: true },
+    application_fee_amount: applicationFeeAmount,
+    transfer_data: { destination: stripeAccountId }
   });
   if (!pi.client_secret) {
     throw new ApiError(500, "STRIPE_ERROR", "Stripe did not return a client secret.");
@@ -213,13 +219,18 @@ export async function retrieveStripePaymentIntent(
 }
 
 export async function createStripeRefund(
-  stripePaymentIntentId: string
+  stripePaymentIntentId: string,
+  options: { reverseTransfer?: boolean; refundApplicationFee?: boolean } = {}
 ): Promise<{ id: string; amount: number; currency: string }> {
   if (testStripeOverride?.createRefund) {
     return testStripeOverride.createRefund(stripePaymentIntentId);
   }
   const stripe = await getStripe();
-  const refund = await stripe.refunds.create({ payment_intent: stripePaymentIntentId });
+  const refund = await stripe.refunds.create({
+    payment_intent: stripePaymentIntentId,
+    ...(options.reverseTransfer && { reverse_transfer: true }),
+    ...(options.refundApplicationFee && { refund_application_fee: true })
+  });
   return { id: refund.id, amount: refund.amount, currency: refund.currency };
 }
 
@@ -261,8 +272,8 @@ export async function createPaymentRecord(input: CreatePaymentRecordInput): Prom
     status: "pending" as PaymentStatus,
     stripePaymentIntentId: input.stripePaymentIntentId,
     stripeChargeId: null,
-    stripeAccountId: null,
-    applicationFeeAmount: null,
+    stripeAccountId: input.stripeAccountId,
+    applicationFeeAmount: input.applicationFeeAmount,
     refundedAmount: 0,
     createdAt: now,
     updatedAt: now

--- a/services/api/src/lib/tenants.ts
+++ b/services/api/src/lib/tenants.ts
@@ -28,6 +28,8 @@ export type TenantProfile = {
   homePageContent: string | null;
   currency: string | null;
   invoiceBusinessName?: string | null;
+  stripeAccountId: string | null;
+  applicationFeePercent: number | null;
   branding: {
     logoAssetId: string | null;
   };
@@ -74,6 +76,8 @@ export type UpdateTenantProfileInput = {
   homePageContent?: string | null;
   currency?: string | null;
   invoiceBusinessName?: string | null;
+  stripeAccountId?: string | null;
+  applicationFeePercent?: number | null;
 };
 
 export type CreateTenantProfileInput = {
@@ -224,6 +228,35 @@ export function normalizeTenantProfilePatch(input: UpdateTenantProfileInput): Up
     }
   }
 
+  if (Object.prototype.hasOwnProperty.call(input, "stripeAccountId")) {
+    if (input.stripeAccountId == null) {
+      out.stripeAccountId = null;
+    } else if (typeof input.stripeAccountId === "string") {
+      const id = input.stripeAccountId.trim();
+      if (!/^acct_[A-Za-z0-9]+$/.test(id)) {
+        details.push({ field: "stripeAccountId", issue: "Must be a valid Stripe account ID (e.g. acct_1ABC...)." });
+      } else {
+        out.stripeAccountId = id;
+      }
+    } else {
+      details.push({ field: "stripeAccountId", issue: "Must be a string or null." });
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, "applicationFeePercent")) {
+    if (input.applicationFeePercent == null) {
+      out.applicationFeePercent = null;
+    } else if (typeof input.applicationFeePercent === "number") {
+      if (input.applicationFeePercent < 0 || input.applicationFeePercent > 100) {
+        details.push({ field: "applicationFeePercent", issue: "Must be between 0 and 100." });
+      } else {
+        out.applicationFeePercent = input.applicationFeePercent;
+      }
+    } else {
+      details.push({ field: "applicationFeePercent", issue: "Must be a number or null." });
+    }
+  }
+
   if (details.length > 0) {
     throw new ApiError(400, "VALIDATION_ERROR", "Invalid tenant profile update payload.", details);
   }
@@ -336,6 +369,8 @@ function toTenantProfile(tenantId: string, item: Record<string, unknown>): Tenan
     homePageContent: asString(item.homePageContent),
     currency: asString(item.currency),
     invoiceBusinessName: asString(item.invoiceBusinessName),
+    stripeAccountId: asString(item.stripeAccountId),
+    applicationFeePercent: typeof item.applicationFeePercent === "number" ? item.applicationFeePercent : null,
     branding: {
       logoAssetId: asString(branding?.logoAssetId)
     },
@@ -572,6 +607,26 @@ export async function updateTenantProfile(
     } else {
       values[":invoiceBusinessName"] = patch.invoiceBusinessName;
       sets.push("#invoiceBusinessName = :invoiceBusinessName");
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(patch, "stripeAccountId")) {
+    names["#stripeAccountId"] = "stripeAccountId";
+    if (patch.stripeAccountId == null) {
+      removes.push("#stripeAccountId");
+    } else {
+      values[":stripeAccountId"] = patch.stripeAccountId;
+      sets.push("#stripeAccountId = :stripeAccountId");
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(patch, "applicationFeePercent")) {
+    names["#applicationFeePercent"] = "applicationFeePercent";
+    if (patch.applicationFeePercent == null) {
+      removes.push("#applicationFeePercent");
+    } else {
+      values[":applicationFeePercent"] = patch.applicationFeePercent;
+      sets.push("#applicationFeePercent = :applicationFeePercent");
     }
   }
 

--- a/tests/orgAssets.integration.test.ts
+++ b/tests/orgAssets.integration.test.ts
@@ -126,6 +126,8 @@ test("orgTenantBrandingGet returns current branding and tenant description", asy
     isActive: true,
     homePageContent: "<p>Welcome</p>",
     currency: null,
+    stripeAccountId: null,
+    applicationFeePercent: null,
     branding: {
       logoAssetId: "ast_logo_1"
     },
@@ -248,6 +250,8 @@ test("orgTenantBrandingUpdate returns logoUrl for immediate frontend refresh", a
     isActive: true,
     homePageContent: null,
     currency: null,
+    stripeAccountId: null,
+    applicationFeePercent: null,
     branding: {
       logoAssetId: "ast_logo_1"
     },
@@ -305,6 +309,8 @@ test("orgTenantBrandingUpdate persists tenant description edits", async () => {
     isActive: true,
     homePageContent: null,
     currency: null,
+    stripeAccountId: null,
+    applicationFeePercent: null,
     branding: {
       logoAssetId: "ast_logo_1"
     },
@@ -319,6 +325,8 @@ test("orgTenantBrandingUpdate persists tenant description edits", async () => {
     isActive: true,
     homePageContent: null,
     currency: null,
+    stripeAccountId: null,
+    applicationFeePercent: null,
     branding: {
       logoAssetId: "ast_logo_1"
     },

--- a/tests/payments.unit.test.ts
+++ b/tests/payments.unit.test.ts
@@ -41,7 +41,9 @@ test("createPaymentRecord writes a pending PAYMENT item to the payments table", 
     variantId: "var_001",
     amount: 5000,
     currency: "aud",
-    stripePaymentIntentId: "pi_test_123"
+    stripePaymentIntentId: "pi_test_123",
+    stripeAccountId: "acct_test_001",
+    applicationFeeAmount: 500
   });
 
   assert.equal(payment.status, "pending");
@@ -50,7 +52,8 @@ test("createPaymentRecord writes a pending PAYMENT item to the payments table", 
   assert.equal(payment.stripePaymentIntentId, "pi_test_123");
   assert.equal(payment.submissionId, null);
   assert.equal(payment.refundedAmount, 0);
-  assert.equal(payment.stripeAccountId, null);
+  assert.equal(payment.stripeAccountId, "acct_test_001");
+  assert.equal(payment.applicationFeeAmount, 500);
   assert.ok(payment.id.startsWith("pay_"));
 
   assert.equal(commands.length, 1);


### PR DESCRIPTION
## Summary

- Adds `stripeAccountId` and `applicationFeePercent` to tenant profiles (schema-less DDB addition, no migration required)
- Payment intents now use Stripe Connect destination charges (`transfer_data.destination` + `application_fee_amount`), so funds route to the connected account minus the platform fee
- Refunds correctly pass `reverse_transfer: true` + `refund_application_fee: true` for Connect charges, pulling funds back from the tenant account instead of debiting the platform
- Two new internal-only API endpoints (`GET/PATCH /internal/tenants/{tenantId}/payment-settings`) guarded by `INTERNAL_TENANT_READ/WRITE` — org users cannot modify their own fee percentage
- SAM template wired with both new Lambda functions and HttpApi routes

## Test plan

- [ ] Run `npm test` in `services/api` — all 161 tests pass
- [ ] Set `stripeAccountId` + `applicationFeePercent` via internal portal for a tenant, confirm values persist
- [ ] With currency + stripeAccountId set, create a payment intent for a paid course — verify Stripe dashboard shows `application_fee_amount` and `transfer_data.destination`
- [ ] With only currency set (no stripeAccountId), confirm 503 `PAYMENT_NOT_CONFIGURED` is returned
- [ ] Trigger a refund on a paid enrollment — verify Stripe dashboard shows the transfer reversed and application fee refunded

🤖 Generated with [Claude Code](https://claude.com/claude-code)