### PR TITLE
feat: per-tenant theming

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -27,6 +27,39 @@ tags:
   name: Org Form Templates
 components:
   schemas:
+    TenantTheme:
+      type: object
+      properties:
+        accentColor:
+          type:
+          - string
+          - "null"
+          pattern: '^#[0-9a-fA-F]{6}$'
+        accentStrongColor:
+          type:
+          - string
+          - "null"
+          pattern: '^#[0-9a-fA-F]{6}$'
+        ctaColor:
+          type:
+          - string
+          - "null"
+          pattern: '^#[0-9a-fA-F]{6}$'
+        bgColor:
+          type:
+          - string
+          - "null"
+          pattern: '^#[0-9a-fA-F]{6}$'
+        textColor:
+          type:
+          - string
+          - "null"
+          pattern: '^#[0-9a-fA-F]{6}$'
+        fontFamily:
+          type:
+          - string
+          - "null"
+          maxLength: 100
     FormTemplate:
       type: object
       properties:
@@ -949,9 +982,12 @@ components:
               type:
               - string
               - "null"
+            theme:
+              $ref: '#/components/schemas/TenantTheme'
           required:
           - logoAssetId
           - logoUrl
+          - theme
         links:
           type: object
           properties:
@@ -1189,6 +1225,8 @@ components:
           type:
           - string
           - "null"
+        theme:
+          $ref: '#/components/schemas/TenantTheme'
       type: object
     TenantBrandingResponse:
       properties:
@@ -1216,6 +1254,8 @@ components:
               type:
               - string
               - "null"
+            theme:
+              $ref: '#/components/schemas/TenantTheme'
             updatedAt:
               format: date-time
               type: string
@@ -1224,6 +1264,7 @@ components:
           - displayName
           - logoAssetId
           - logoUrl
+          - theme
           - updatedAt
       type: object
       required:

--- a/services/api/src/handlers/orgTenantBrandingGet.ts
+++ b/services/api/src/handlers/orgTenantBrandingGet.ts
@@ -15,6 +15,7 @@ async function toBrandingSettings(profile: Awaited<ReturnType<typeof getTenantPr
     homePageContent: profile.homePageContent,
     logoAssetId,
     logoUrl: await resolveAssetPublicUrl(profile.tenantId, logoAssetId),
+    theme: profile.branding.theme,
     updatedAt: profile.updatedAt
   };
 }

--- a/services/api/src/handlers/orgTenantBrandingUpdate.ts
+++ b/services/api/src/handlers/orgTenantBrandingUpdate.ts
@@ -8,12 +8,20 @@ import { ApiError } from "../lib/errors";
 import { emitBrandingUpdateMetric, logFrontendAudit } from "../lib/frontendObservability";
 import { errorResponse, jsonResponse } from "../lib/http";
 import { parseJsonBody } from "../lib/request";
-import { getTenantProfile, updateTenantBranding, updateTenantProfile } from "../lib/tenants";
+import {
+  getTenantProfile,
+  normalizeThemePatch,
+  type TenantTheme,
+  updateTenantBranding,
+  updateTenantProfile,
+  updateTenantTheme,
+} from "../lib/tenants";
 
 type UpdateTenantBrandingBody = {
   logoAssetId?: string | null;
   description?: string | null;
   homePageContent?: string | null;
+  theme?: Partial<TenantTheme>;
 };
 
 async function toBrandingSettings(profile: Awaited<ReturnType<typeof getTenantProfile>>) {
@@ -25,6 +33,7 @@ async function toBrandingSettings(profile: Awaited<ReturnType<typeof getTenantPr
     homePageContent: profile.homePageContent,
     logoAssetId,
     logoUrl: await resolveAssetPublicUrl(profile.tenantId, logoAssetId),
+    theme: profile.branding.theme,
     updatedAt: profile.updatedAt
   };
 }
@@ -56,6 +65,20 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
       ]);
     }
 
+    let themePatch: Partial<TenantTheme> = {};
+    if (body.theme !== undefined) {
+      if (typeof body.theme !== "object" || body.theme === null) {
+        throw new ApiError(400, "VALIDATION_ERROR", "theme must be an object.", [
+          { field: "theme", issue: "invalid_type" }
+        ]);
+      }
+      const { patch, details } = normalizeThemePatch(body.theme);
+      if (details.length > 0) {
+        throw new ApiError(400, "VALIDATION_ERROR", "Invalid theme fields.", details);
+      }
+      themePatch = patch;
+    }
+
     if (Object.prototype.hasOwnProperty.call(body, "logoAssetId")) {
       await updateTenantBranding(auth.tenantId, body.logoAssetId ?? null);
     }
@@ -72,6 +95,9 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
           : {})
       });
     }
+    if (Object.keys(themePatch).length > 0) {
+      await updateTenantTheme(auth.tenantId, themePatch);
+    }
     const data = await toBrandingSettings(await getTenantProfile(auth.tenantId));
     emitBrandingUpdateMetric();
     logFrontendAudit("frontend_branding_updated", {
@@ -87,7 +113,7 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
       resourceId: auth.tenantId,
       correlationId: correlation.correlationId,
       requestId: correlation.requestId,
-      details: { logoAssetId: data.logoAssetId }
+      details: { logoAssetId: data.logoAssetId, themePatch }
     });
     return jsonResponse(200, { data }, correlation);
   } catch (error) {

--- a/services/api/src/lib/tenants.ts
+++ b/services/api/src/lib/tenants.ts
@@ -364,6 +364,9 @@ function normalizeTenantProfileCreate(input: CreateTenantProfileInput): {
 }
 
 const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+// Allowlist: letters, digits, spaces, commas, hyphens, underscores, periods, single/double quotes.
+// Blocks CSS injection tokens: ; { } / * < > \ ( ) etc.
+const FONT_FAMILY_SAFE_RE = /^[a-zA-Z0-9 ,\-_.'"]+$/;
 
 export function normalizeThemePatch(input: Partial<TenantTheme>): {
   patch: Partial<TenantTheme>;
@@ -393,6 +396,8 @@ export function normalizeThemePatch(input: Partial<TenantTheme>): {
       const trimmed = val.trim();
       if (trimmed.length > MAX_FONT_FAMILY_LENGTH) {
         details.push({ field: "fontFamily", issue: `Must be at most ${MAX_FONT_FAMILY_LENGTH} characters.` });
+      } else if (trimmed.length > 0 && !FONT_FAMILY_SAFE_RE.test(trimmed)) {
+        details.push({ field: "fontFamily", issue: "Contains disallowed characters. Use a CSS font-family stack with letters, digits, spaces, commas, hyphens, and quotes only." });
       } else {
         patch.fontFamily = trimmed.length > 0 ? trimmed : null;
       }

--- a/services/api/src/lib/tenants.ts
+++ b/services/api/src/lib/tenants.ts
@@ -12,6 +12,15 @@ import { resolveTenantIdByCode } from "./courses";
 import { ApiError } from "./errors";
 import { normalizeTenantCode } from "./tenantCodes";
 
+export type TenantTheme = {
+  accentColor: string | null;
+  accentStrongColor: string | null;
+  ctaColor: string | null;
+  bgColor: string | null;
+  textColor: string | null;
+  fontFamily: string | null;
+};
+
 export type TenantBranding = {
   tenantId: string;
   logoAssetId: string | null;
@@ -32,6 +41,7 @@ export type TenantProfile = {
   applicationFeePercent: number | null;
   branding: {
     logoAssetId: string | null;
+    theme: TenantTheme;
   };
   createdAt: string | null;
   updatedAt: string;
@@ -62,6 +72,7 @@ export type PublicTenantHome = {
   branding: {
     logoAssetId: string | null;
     logoUrl: string | null;
+    theme: TenantTheme;
   };
   links: {
     home: string;
@@ -94,6 +105,7 @@ const TENANT_PROFILE_GSI1PK = "ENTITY_TYPE#TENANT";
 const MAX_DISPLAY_NAME_LENGTH = 120;
 const MAX_DESCRIPTION_LENGTH = 500;
 const MAX_HOME_PAGE_CONTENT_LENGTH = 8000;
+const MAX_FONT_FAMILY_LENGTH = 100;
 let testPublicTenantDirectoryOverride: ((limit: number) => Promise<PublicTenantDirectoryItem[]>) | null = null;
 let testPublicTenantHomeOverride: ((tenantCode: string) => Promise<PublicTenantHome>) | null = null;
 let testGetTenantProfileOverride: ((tenantId: string) => Promise<TenantProfile>) | null = null;
@@ -102,6 +114,9 @@ let testUpdateTenantBrandingOverride:
   | null = null;
 let testUpdateTenantProfileOverride:
   | ((tenantId: string, input: UpdateTenantProfileInput) => Promise<TenantProfile>)
+  | null = null;
+let testUpdateTenantThemeOverride:
+  | ((tenantId: string, patch: Partial<TenantTheme>) => Promise<void>)
   | null = null;
 
 function tenantPk(tenantId: string): string {
@@ -348,6 +363,47 @@ function normalizeTenantProfileCreate(input: CreateTenantProfileInput): {
   };
 }
 
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+
+export function normalizeThemePatch(input: Partial<TenantTheme>): {
+  patch: Partial<TenantTheme>;
+  details: Array<{ field: string; issue: string }>;
+} {
+  const patch: Partial<TenantTheme> = {};
+  const details: Array<{ field: string; issue: string }> = [];
+
+  const colorFields = ["accentColor", "accentStrongColor", "ctaColor", "bgColor", "textColor"] as const;
+  for (const field of colorFields) {
+    if (!Object.prototype.hasOwnProperty.call(input, field)) continue;
+    const val = input[field];
+    if (val === null) {
+      patch[field] = null;
+    } else if (typeof val === "string" && HEX_COLOR_RE.test(val)) {
+      patch[field] = val.toLowerCase();
+    } else {
+      details.push({ field, issue: "Must be a 6-digit hex color (e.g. #6c47ff) or null." });
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, "fontFamily")) {
+    const val = input.fontFamily;
+    if (val === null) {
+      patch.fontFamily = null;
+    } else if (typeof val === "string") {
+      const trimmed = val.trim();
+      if (trimmed.length > MAX_FONT_FAMILY_LENGTH) {
+        details.push({ field: "fontFamily", issue: `Must be at most ${MAX_FONT_FAMILY_LENGTH} characters.` });
+      } else {
+        patch.fontFamily = trimmed.length > 0 ? trimmed : null;
+      }
+    } else {
+      details.push({ field: "fontFamily", issue: "Must be a string or null." });
+    }
+  }
+
+  return { patch, details };
+}
+
 function toTenantProfile(tenantId: string, item: Record<string, unknown>): TenantProfile {
   const tenantCode = asString(item.tenantCode);
   const displayName = asString(item.displayName);
@@ -356,6 +412,7 @@ function toTenantProfile(tenantId: string, item: Record<string, unknown>): Tenan
   }
 
   const branding = item.branding as Record<string, unknown> | undefined;
+  const rawTheme = branding?.theme as Record<string, unknown> | undefined;
   return {
     tenantId,
     tenantCode: normalizeTenantCode(tenantCode, {
@@ -372,7 +429,15 @@ function toTenantProfile(tenantId: string, item: Record<string, unknown>): Tenan
     stripeAccountId: asString(item.stripeAccountId),
     applicationFeePercent: typeof item.applicationFeePercent === "number" ? item.applicationFeePercent : null,
     branding: {
-      logoAssetId: asString(branding?.logoAssetId)
+      logoAssetId: asString(branding?.logoAssetId),
+      theme: {
+        accentColor: asString(rawTheme?.accentColor),
+        accentStrongColor: asString(rawTheme?.accentStrongColor),
+        ctaColor: asString(rawTheme?.ctaColor),
+        bgColor: asString(rawTheme?.bgColor),
+        textColor: asString(rawTheme?.textColor),
+        fontFamily: asString(rawTheme?.fontFamily),
+      }
     },
     createdAt: asString(item.createdAt),
     updatedAt: asString(item.updatedAt) ?? new Date().toISOString()
@@ -475,7 +540,8 @@ export async function getPublicTenantHomeByCode(tenantCode: string): Promise<Pub
     isActive: profile.isActive,
     branding: {
       logoAssetId: profile.branding.logoAssetId,
-      logoUrl: await resolveAssetPublicUrl(profile.tenantId, profile.branding.logoAssetId)
+      logoUrl: await resolveAssetPublicUrl(profile.tenantId, profile.branding.logoAssetId),
+      theme: profile.branding.theme
     },
     links: {
       home: `/v1/public/${profile.tenantCode}/tenant-home`,
@@ -536,6 +602,34 @@ export async function updateTenantBranding(
     logoUrl: await resolveAssetPublicUrl(tenantId, logoAssetId),
     updatedAt: now
   };
+}
+
+export async function updateTenantTheme(tenantId: string, patch: Partial<TenantTheme>): Promise<void> {
+  if (Object.keys(patch).length === 0) return;
+  if (testUpdateTenantThemeOverride) {
+    return testUpdateTenantThemeOverride(tenantId, patch);
+  }
+  const profile = await getTenantProfile(tenantId);
+  const current = profile.branding.theme;
+  const merged: TenantTheme = { ...current, ...patch };
+  const now = new Date().toISOString();
+  await ddb.send(
+    new UpdateCommand({
+      TableName: tableName,
+      Key: { PK: tenantPk(tenantId), SK: "PROFILE" },
+      ConditionExpression: "attribute_exists(PK) AND attribute_exists(SK)",
+      UpdateExpression: "SET #branding.#theme = :theme, #updatedAt = :updatedAt",
+      ExpressionAttributeNames: {
+        "#branding": "branding",
+        "#theme": "theme",
+        "#updatedAt": "updatedAt"
+      },
+      ExpressionAttributeValues: {
+        ":theme": merged,
+        ":updatedAt": now
+      }
+    })
+  );
 }
 
 export async function updateTenantProfile(
@@ -754,11 +848,17 @@ export const __tenantsTestHooks = {
   ): void {
     testUpdateTenantProfileOverride = loader;
   },
+  setUpdateTenantThemeOverride(
+    loader: ((tenantId: string, patch: Partial<TenantTheme>) => Promise<void>) | null
+  ): void {
+    testUpdateTenantThemeOverride = loader;
+  },
   reset(): void {
     testPublicTenantDirectoryOverride = null;
     testPublicTenantHomeOverride = null;
     testGetTenantProfileOverride = null;
     testUpdateTenantBrandingOverride = null;
     testUpdateTenantProfileOverride = null;
+    testUpdateTenantThemeOverride = null;
   }
 };

--- a/tests/orgAssets.integration.test.ts
+++ b/tests/orgAssets.integration.test.ts
@@ -129,7 +129,8 @@ test("orgTenantBrandingGet returns current branding and tenant description", asy
     stripeAccountId: null,
     applicationFeePercent: null,
     branding: {
-      logoAssetId: "ast_logo_1"
+      logoAssetId: "ast_logo_1",
+      theme: { accentColor: null, accentStrongColor: null, ctaColor: null, bgColor: null, textColor: null, fontFamily: null }
     },
     createdAt: "2026-03-20T01:00:00Z",
     updatedAt: "2026-03-25T01:00:00Z"
@@ -253,7 +254,8 @@ test("orgTenantBrandingUpdate returns logoUrl for immediate frontend refresh", a
     stripeAccountId: null,
     applicationFeePercent: null,
     branding: {
-      logoAssetId: "ast_logo_1"
+      logoAssetId: "ast_logo_1",
+      theme: { accentColor: null, accentStrongColor: null, ctaColor: null, bgColor: null, textColor: null, fontFamily: null }
     },
     createdAt: "2026-03-20T01:00:00Z",
     updatedAt: "2026-03-25T01:00:00Z"
@@ -312,7 +314,8 @@ test("orgTenantBrandingUpdate persists tenant description edits", async () => {
     stripeAccountId: null,
     applicationFeePercent: null,
     branding: {
-      logoAssetId: "ast_logo_1"
+      logoAssetId: "ast_logo_1",
+      theme: { accentColor: null, accentStrongColor: null, ctaColor: null, bgColor: null, textColor: null, fontFamily: null }
     },
     createdAt: "2026-03-20T01:00:00Z",
     updatedAt: "2026-03-25T01:00:00Z"
@@ -328,7 +331,8 @@ test("orgTenantBrandingUpdate persists tenant description edits", async () => {
     stripeAccountId: null,
     applicationFeePercent: null,
     branding: {
-      logoAssetId: "ast_logo_1"
+      logoAssetId: "ast_logo_1",
+      theme: { accentColor: null, accentStrongColor: null, ctaColor: null, bgColor: null, textColor: null, fontFamily: null }
     },
     createdAt: "2026-03-20T01:00:00Z",
     updatedAt: "2026-03-25T01:00:00Z"
@@ -364,6 +368,121 @@ test("orgTenantBrandingUpdate persists tenant description edits", async () => {
     __auditTestHooks.reset();
     __assetsTestHooks.reset();
     __tenantsTestHooks.reset();
+    process.env.AUTH_MODE = oldMode;
+  }
+});
+
+test("orgTenantBrandingUpdate persists theme patch and returns updated theme", async () => {
+  const oldMode = process.env.AUTH_MODE;
+  process.env.AUTH_MODE = "mock";
+  __auditTestHooks.suppressWrites();
+  __assetsTestHooks.setResolveAssetPublicUrlOverride(async (_tenantId, assetId) =>
+    assetId ? `https://assets.example.com/${assetId}` : null
+  );
+  __tenantsTestHooks.setUpdateTenantThemeOverride(async () => undefined);
+  __tenantsTestHooks.setGetTenantProfileOverride(async () => ({
+    tenantId: "ten_1",
+    tenantCode: "acme-training",
+    displayName: "Acme Training",
+    description: null,
+    isActive: true,
+    homePageContent: null,
+    currency: null,
+    stripeAccountId: null,
+    applicationFeePercent: null,
+    branding: {
+      logoAssetId: null,
+      theme: { accentColor: "#e63946", accentStrongColor: null, ctaColor: null, bgColor: null, textColor: null, fontFamily: null }
+    },
+    createdAt: "2026-03-20T01:00:00Z",
+    updatedAt: "2026-03-25T01:00:00Z"
+  }));
+
+  try {
+    const event = {
+      version: "2.0",
+      routeKey: "PATCH /org/branding",
+      rawPath: "/org/branding",
+      rawQueryString: "",
+      body: JSON.stringify({ theme: { accentColor: "#e63946" } }),
+      headers: {
+        "content-type": "application/json",
+        "x-user-id": "usr_1",
+        "x-tenant-id": "ten_1",
+        "x-role": "org_admin"
+      },
+      requestContext: baseContext("/org/branding", "PATCH", "req_branding_theme_ok"),
+      isBase64Encoded: false
+    } as APIGatewayProxyEventV2;
+
+    const result = asStructuredResult(await brandingHandler(event, {} as never, () => undefined));
+    assert.equal(result.statusCode, 200);
+    const body = JSON.parse(result.body as string) as {
+      data: { theme: { accentColor: string | null } };
+    };
+    assert.equal(body.data.theme.accentColor, "#e63946");
+  } finally {
+    __auditTestHooks.reset();
+    __assetsTestHooks.reset();
+    __tenantsTestHooks.reset();
+    process.env.AUTH_MODE = oldMode;
+  }
+});
+
+test("orgTenantBrandingUpdate returns 400 for invalid hex color in theme", async () => {
+  const oldMode = process.env.AUTH_MODE;
+  process.env.AUTH_MODE = "mock";
+  try {
+    const event = {
+      version: "2.0",
+      routeKey: "PATCH /org/branding",
+      rawPath: "/org/branding",
+      rawQueryString: "",
+      body: JSON.stringify({ theme: { accentColor: "not-a-color" } }),
+      headers: {
+        "content-type": "application/json",
+        "x-user-id": "usr_1",
+        "x-tenant-id": "ten_1",
+        "x-role": "org_admin"
+      },
+      requestContext: baseContext("/org/branding", "PATCH", "req_branding_bad_hex"),
+      isBase64Encoded: false
+    } as APIGatewayProxyEventV2;
+
+    const result = asStructuredResult(await brandingHandler(event, {} as never, () => undefined));
+    assert.equal(result.statusCode, 400);
+    const body = JSON.parse(result.body as string) as { error: { code: string } };
+    assert.equal(body.error.code, "VALIDATION_ERROR");
+  } finally {
+    process.env.AUTH_MODE = oldMode;
+  }
+});
+
+test("orgTenantBrandingUpdate returns 400 when fontFamily exceeds 100 characters", async () => {
+  const oldMode = process.env.AUTH_MODE;
+  process.env.AUTH_MODE = "mock";
+  try {
+    const event = {
+      version: "2.0",
+      routeKey: "PATCH /org/branding",
+      rawPath: "/org/branding",
+      rawQueryString: "",
+      body: JSON.stringify({ theme: { fontFamily: "a".repeat(101) } }),
+      headers: {
+        "content-type": "application/json",
+        "x-user-id": "usr_1",
+        "x-tenant-id": "ten_1",
+        "x-role": "org_admin"
+      },
+      requestContext: baseContext("/org/branding", "PATCH", "req_branding_long_font"),
+      isBase64Encoded: false
+    } as APIGatewayProxyEventV2;
+
+    const result = asStructuredResult(await brandingHandler(event, {} as never, () => undefined));
+    assert.equal(result.statusCode, 400);
+    const body = JSON.parse(result.body as string) as { error: { code: string } };
+    assert.equal(body.error.code, "VALIDATION_ERROR");
+  } finally {
     process.env.AUTH_MODE = oldMode;
   }
 });

--- a/tests/orgAssets.integration.test.ts
+++ b/tests/orgAssets.integration.test.ts
@@ -486,3 +486,32 @@ test("orgTenantBrandingUpdate returns 400 when fontFamily exceeds 100 characters
     process.env.AUTH_MODE = oldMode;
   }
 });
+
+test("orgTenantBrandingUpdate returns 400 for CSS injection attempt in fontFamily", async () => {
+  const oldMode = process.env.AUTH_MODE;
+  process.env.AUTH_MODE = "mock";
+  try {
+    const event = {
+      version: "2.0",
+      routeKey: "PATCH /org/branding",
+      rawPath: "/org/branding",
+      rawQueryString: "",
+      body: JSON.stringify({ theme: { fontFamily: "serif; } body { display:none } /*" } }),
+      headers: {
+        "content-type": "application/json",
+        "x-user-id": "usr_1",
+        "x-tenant-id": "ten_1",
+        "x-role": "org_admin"
+      },
+      requestContext: baseContext("/org/branding", "PATCH", "req_branding_css_inject"),
+      isBase64Encoded: false
+    } as APIGatewayProxyEventV2;
+
+    const result = asStructuredResult(await brandingHandler(event, {} as never, () => undefined));
+    assert.equal(result.statusCode, 400);
+    const body2 = JSON.parse(result.body as string) as { error: { code: string } };
+    assert.equal(body2.error.code, "VALIDATION_ERROR");
+  } finally {
+    process.env.AUTH_MODE = oldMode;
+  }
+});

--- a/tests/publicPortalPayloads.integration.test.ts
+++ b/tests/publicPortalPayloads.integration.test.ts
@@ -102,7 +102,8 @@ test("public tenant home includes branding logoUrl and self link", async () => {
     isActive: true,
     branding: {
       logoAssetId: "ast_logo",
-      logoUrl: "https://cdn.onlineforms.com/assets/ast_logo"
+      logoUrl: "https://cdn.onlineforms.com/assets/ast_logo",
+      theme: { accentColor: null, accentStrongColor: null, ctaColor: null, bgColor: null, textColor: null, fontFamily: null }
     },
     links: {
       home: "/v1/public/std-school/tenant-home",


### PR DESCRIPTION
## Summary

- Adds `TenantTheme` type (6 fields: `accentColor`, `accentStrongColor`, `ctaColor`, `bgColor`, `textColor`, `fontFamily`) to the tenant data model
- `normalizeThemePatch` validator enforces hex color pattern and a character allowlist on `fontFamily` to block stored CSS injection
- `updateTenantTheme` uses a read-merge-write pattern to safely update the `branding.theme` sub-map on existing DynamoDB items that predate the field
- Branding GET (`/org/branding`) and PATCH (`/org/branding`) endpoints extended to read and write theme
- `getPublicTenantHomeByCode` now returns `theme` so `TenantRouteGuard` can apply it to all public tenant pages
- `openapi.yaml` extended with `TenantTheme` schema component, referenced in branding request/response and public tenant home

## Test plan

- [ ] 165 integration tests pass (`npm test`)
- [ ] `PATCH /org/branding` with `{ "theme": { "accentColor": "#e63946" } }` returns 200 with updated theme
- [ ] `PATCH /org/branding` with invalid hex `"not-a-color"` returns 400 `VALIDATION_ERROR`
- [ ] `PATCH /org/branding` with `fontFamily` containing `;` or `}` returns 400 `VALIDATION_ERROR`
- [ ] `GET /public/{code}/tenant-home` response includes `branding.theme`

🤖 Generated with [Claude Code](https://claude.com/claude-code)