### PR TITLE
hotfix: add localhost:5173 as Cognito callback URL for local dev

### DIFF
--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -431,6 +431,7 @@ Resources:
         - profile
       CallbackURLs:
         - !Ref CognitoHostedUiCallbackUrl
+        - http://localhost:5173/org/login
       LogoutURLs:
         - !Ref CognitoHostedUiLogoutUrl
         - !Ref CognitoHostedUiHomeLogoutUrl


### PR DESCRIPTION
Allows developers running the frontend locally (npm run dev) to use VITE_AUTH_MODE=cognito and obtain real tokens without a separate CLI update-user-pool-client step.

## Summary

- 

## Linked issue

Fixes #

## Root cause

- 

## Changes made

- 

## Validation

- [ ] Build passes
- [ ] Tests updated/passing
- [ ] Manual verification completed

## Risk and rollback

- Risk:
- Rollback:
