### PR TITLE
fix: exclude variant items from GET /courses list

### DIFF
--- a/services/api/src/lib/courses.ts
+++ b/services/api/src/lib/courses.ts
@@ -754,9 +754,11 @@ export async function listCourses(tenantId: string, input: ListCoursesInput = {}
     new QueryCommand({
       TableName: tableName,
       KeyConditionExpression: "PK = :pk AND begins_with(SK, :sk)",
+      FilterExpression: "entityType = :entityType",
       ExpressionAttributeValues: {
         ":pk": tenantPk(tenantId),
-        ":sk": "COURSE#"
+        ":sk": "COURSE#",
+        ":entityType": "COURSE"
       }
     })
   );


### PR DESCRIPTION
## Summary
- `GET /courses` was returning variant titles (e.g. "Online class") instead of actual course titles
- Root cause: `listCourses` queried DynamoDB with `begins_with(SK, "COURSE#")`, which also matched variant items whose SK is `COURSE#<id>#VARIANT#<id>`
- Fix: added `FilterExpression: entityType = "COURSE"` to the query so only course items are returned

## Test plan
- [ ] `GET /courses` returns correct course titles for all courses
- [ ] `GET /courses/{id}` continues to return the correct course title
- [ ] Courses with variants are still returned in the list (variants are excluded from list, not courses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)