### PR TITLE
fix: enrollment CAPTCHA failure, member email, course list titles

### DIFF
--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -121,7 +121,7 @@ Mappings:
     test:
       Enabled: "false"
     stage:
-      Enabled: "true"
+      Enabled: "false"
     prod:
       Enabled: "true"
 


### PR DESCRIPTION
## Summary
- **GET /courses returning wrong titles** — `listCourses` queried DynamoDB with `begins_with(SK, "COURSE#")` which also matched variant items (`COURSE#<id>#VARIANT#<id>`), returning variant titles instead of course titles. Fixed by adding `FilterExpression: entityType = "COURSE"`.
- **Org users page email always empty** — `updateTenantMemberRole` returned a hardcoded `email: null` in its response. If the frontend merges this into local state, every member whose role has been updated shows blank email. Fixed by spreading the already-fetched `targetMember` and overriding only `role` and `updatedAt`. Also eliminated a redundant `listTenantMembers` call.
- **Public enrollment CAPTCHA_FAILED on stage** — Stage was configured with `TURNSTILE_ENABLED=true` but no Cloudflare Turnstile account or keys have been set up, causing all enrollment submissions to fail. Disabled CAPTCHA on stage until Turnstile is properly configured; prod remains enabled.

## Test plan
- [ ] `GET /courses` returns actual course titles, not variant titles
- [ ] Org users page shows correct email for all members, including after a role change
- [ ] `PATCH /org/tenants/{id}/members/{userId}` response includes the real member email
- [ ] Public enrollment form submits successfully on stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)