### PR TITLE
fix: accept idem_ idempotency key format from frontend

### DIFF
--- a/services/api/src/lib/submissions.ts
+++ b/services/api/src/lib/submissions.ts
@@ -215,8 +215,9 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 function normalizeIdempotencyKey(idempotencyKey: string): string {
   const key = idempotencyKey.trim().toLowerCase();
   const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
-  if (!uuidPattern.test(key)) {
-    throw new ApiError(400, "VALIDATION_ERROR", "Idempotency-Key must be a valid UUID.");
+  const idemPattern = /^idem_[0-9a-z]{16,}$/;
+  if (!uuidPattern.test(key) && !idemPattern.test(key)) {
+    throw new ApiError(400, "VALIDATION_ERROR", "Idempotency-Key must be a valid UUID or idem_<random> key.");
   }
   return key;
 }


### PR DESCRIPTION
## Summary
The backend `normalizeIdempotencyKey` only accepted strict UUID format (`xxxxxxxx-xxxx-...`), but the frontend generates keys as `idem_<random-hex>` (e.g. `idem_a1b2c3d4e5f6...`). This mismatch caused every public enrollment submission to fail with `VALIDATION_ERROR: Idempotency-Key must be a valid UUID`.

Fix: accept both formats in the validation regex.

## Test plan
- [ ] Public enrollment form submits successfully
- [ ] Duplicate submissions with the same `idem_` key are correctly deduplicated (409 CONFLICT)
- [ ] Invalid keys (random strings, empty) still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)